### PR TITLE
Potential fix for code scanning alert no. 1: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/ruby/test/application_test.rb
+++ b/ruby/test/application_test.rb
@@ -9,7 +9,7 @@ class ApplicationTest < Minitest::Test
     @filename = 'users.json'
     @filepath = File.join(dirname, filename)
     FileUtils.mkdir_p(dirname) unless Dir.exist?(dirname)
-    IO.write(filepath, json_data)
+    File.write(filepath, json_data)
   end
 
   def teardown


### PR DESCRIPTION
Potential fix for [https://github.com/hayat01sh1da/json-data-sorters/security/code-scanning/1](https://github.com/hayat01sh1da/json-data-sorters/security/code-scanning/1)

To fix the problem, we should replace the use of `IO.write` with `File.write`. This change will mitigate the risk of executing arbitrary code through a manipulated file path. The functionality of the code will remain the same, as `File.write` provides the same capabilities as `IO.write` for writing data to a file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
