### PR TITLE
Potential fix for code scanning alert no. 2: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/ruby/src/application.rb
+++ b/ruby/src/application.rb
@@ -40,7 +40,7 @@ class Application
   def run
     FileUtils.mkdir(dirname) unless Dir.exist?(dirname)
     FileUtils.touch(filepath) unless File.exist?(filepath)
-    IO.write(filepath, dump_sorted_json_data)
+    File.write(filepath, dump_sorted_json_data)
   end
 
   private


### PR DESCRIPTION
Potential fix for [https://github.com/hayat01sh1da/json-data-sorters/security/code-scanning/2](https://github.com/hayat01sh1da/json-data-sorters/security/code-scanning/2)

To fix the problem, we should replace the use of `IO.write` with `File.write`. This change will mitigate the risk of arbitrary code execution by ensuring that the file operations are handled more securely. Specifically, we need to update line 43 in the `run` method to use `File.write` instead of `IO.write`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
