### PR TITLE
Update Ubuntu to Ubuntu 25.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## 1. Common Environment
 
-- WSL(Ubuntu 24.04.3 LTS)
+- WSL (Ubuntu 25.10)
 
 ## 2. READMEs
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,11 +5,11 @@
 
 ## Ecosystem & Compatibility
 
-| Component            | Version(s) / Tooling            | Notes |
-| -------------------- | ------------------------------ | ----- |
-| OS baseline          | WSL (Ubuntu 24.04.3 LTS)       | Shared across Ruby and Python implementations. |
-| Ruby sorter          | Ruby 4.0.2 (`.ruby-version`)   | Uses Ruby stdlib (`JSON`, `FileUtils`). Declare extra gems if introduced. |
-| Python sorter        | CPython 3.14.3 (`.python-version`) | Uses Python stdlib (`json`, `argparse`). Add `requirements.txt` for third-party modules. |
+| Component     | Version(s) / Tooling               | Notes                                                                                    |
+| ------------- | ---------------------------------- | ---------------------------------------------------------------------------------------- |
+| OS baseline   | WSL (Ubuntu 25.10)                 | Shared environment across tracks.                                                        |
+| Ruby sorter   | Ruby 4.0.2 (`.ruby-version`)       | Uses Ruby stdlib (`JSON`, `FileUtils`). Declare extra gems if introduced.                |
+| Python sorter | CPython 3.14.3 (`.python-version`) | Uses Python stdlib (`json`, `argparse`). Add `requirements.txt` for third-party modules. |
 
 ## Backward Compatibility
 


### PR DESCRIPTION
# Ubuntu 24.04 LTS vs Ubuntu 25.10 — Summary of Differences

> **Note:** The version referenced as "24.0.3" is interpreted as **Ubuntu 24.04 LTS** (Noble Numbat). The latest point release at the time of writing is **24.04.4**.

---

## 1. Overview

| | Ubuntu 24.04 LTS (Noble Numbat) | Ubuntu 25.10 (Questing Quokka) |
|---|---|---|
| **Release date** | 25 April 2024 | 9 October 2025 |
| **Release type** | Long-Term Support (LTS) | Interim (standard) |
| **Support window** | 5 years standard (until May 2029); up to 15 years with Ubuntu Pro | 9 months (until July 2026) |
| **Image size** | ~5.9 GB | ~5.3 GB |

---

## 2. Linux Kernel

| | 24.04 LTS | 25.10 |
|---|---|---|
| **Kernel version** | 6.8 | 6.17 |
| **Notable additions** | Improved gamepad support, better swap memory handling, Year 2038 fix for 32-bit armhf | Latest hardware enablement, continued hardware support improvements |

---

## 3. Desktop Environment (GNOME)

| | 24.04 LTS | 25.10 |
|---|---|---|
| **GNOME version** | 46 | 49 |
| **Display server** | Wayland (X11 still available) | Wayland default; **X11 session disabled by default** |
| **Key GNOME changes** | Apps migrated to libadwaita/GTK4, Nautilus quality-of-life features, Wi-Fi QR codes, reorganised settings, tap-to-click default | Accessibility tools & media controls on lock screen, fractional scaling sharpening, pointer wrap, variable-refresh-rate cursors, "Startup Applications" app replaced by settings panel |
| **Terminal emulator** | GNOME Terminal | **Ptyxis** (new default; container & remote connection support) |
| **Image viewer** | Eye of GNOME | **Loupe** (new default) |
| **Camera app** | GNOME Snapshot (extended install) | GNOME Snapshot |
| **Document viewer** | Evince | Evince (Papers introduced in 25.04) |

---

## 4. Init & System Tooling

| | 24.04 LTS | 25.10 |
|---|---|---|
| **systemd** | v255.4 | Updated |
| **initramfs generation** | Traditional (update-initramfs) | **Dracut** (new default) |
| **Time sync** | systemd-timesyncd | **chrony** (new default) |
| **sudo** | GNU sudo | **sudo-rs** (Rust rewrite) |
| **Core utilities** | GNU Coreutils | **rust-coreutils** (Rust rewrite) |
| **Package manager** | APT (standard) | **APT 3.1** with upcoming history-related features |
| **Network config** | Netplan v1.0 (default since 23.10) | Netplan (continued) |

---

## 5. Default Applications & Server Changes

| | 24.04 LTS | 25.10 |
|---|---|---|
| **Update notifications** | Standard window-based notification | **Notification + tray applet** (no more focus-stealing windows) |
| **Default download tool (server)** | wget | **wcurl** (wget removed from default server install) |
| **Terminal multiplexer (server)** | Byobu / GNU Screen available | **tmux** (Byobu & GNU Screen removed) |
| **Thunderbird** | Snap only | Snap only |
| **Firefox** | Snap only | Snap only |

---

## 6. Security & Encryption

| | 24.04 LTS | 25.10 |
|---|---|---|
| **TPM-backed FDE** | Experimental option in installer | **Enhanced** — experimental installer option + support in Firmware Updater and Security Center |
| **Security Center** | Not present (introduced in 24.10) | Available with fine-grained app permissions |
| **Flatpak** | Works normally | Initially broken due to AppArmor bug (fixed 15 Oct 2025) |

---

## 7. Desktop & Theming

| | 24.04 LTS | 25.10 |
|---|---|---|
| **Yaru theme** | Light/dark with 10 accent colours | Updated (new trash can icon, dock icon outline aligned with dock edge) |
| **Desktop icons** | Standard | **Improved keyboard navigation & screenreader support** |
| **Boot experience** | Standard | **New boot spinner** fixing visual glitches |
| **Dock** | Standard | Progress bars for snap updates (from 24.10), rounded radii fix |

---

## 8. Architecture & Hardware

| | 24.04 LTS | 25.10 |
|---|---|---|
| **Raspberry Pi** | Supported; separate Bluetooth package removed | **Minimal install** image, **tryboot** mechanism for boot reliability |
| **RISC-V** | Available | Raised profile requirement to **RVA23** |
| **32-bit armhf** | Patched for Year 2038; no future standalone images | Continued |

---

## 9. Support Lifecycle Comparison

```
Ubuntu 24.04 LTS
├── Standard security maintenance ── until May 2029  (5 years)
├── Expanded Security Maintenance ── until Apr 2034  (10 years via Ubuntu Pro)
├── Break/bug support ───────────── until Apr 2034
└── Legacy add-on ───────────────── until Apr 2039  (15 years total)

Ubuntu 25.10
├── Standard security maintenance ── until Jul 2026  (9 months)
├── Expanded Security Maintenance ── Not applicable
├── Break/bug support ───────────── Not applicable
└── Legacy add-on ───────────────── Not applicable
```

---

## 10. Known Issues at Launch (25.10)

- **Flatpak broken at release** — AppArmor issue prevented Flatpak installs; fixed 15 October 2025.
- **Automatic updates bug** — A bug in rust-coreutils' `date` command prevented automatic software update checks; fixed 22 October 2025. Manual `apt` updates were unaffected.

---

## 11. Key Takeaways

| Consideration | Recommendation |
|---|---|
| **Stability & long-term use** | **Ubuntu 24.04 LTS** — 5+ years of support, enterprise-ready |
| **Cutting-edge features** | **Ubuntu 25.10** — Latest kernel (6.17), GNOME 49, Rust-based core utilities |
| **Production servers** | **Ubuntu 24.04 LTS** — Longer maintenance window, proven stability |
| **Developers & enthusiasts** | **Ubuntu 25.10** — Newest toolchains, Ptyxis terminal, Dracut, chrony |
| **Raspberry Pi projects** | **Ubuntu 25.10** — Minimal install image, tryboot reliability |

---

*Report generated on 26 March 2026. Sources: ubuntu.com, Wikipedia (Ubuntu version history), Canonical Discourse.*