### PR TITLE
[ruby] Switch Gems to Install from Job to Job

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -1,5 +1,9 @@
 name: Setup Ruby Environment
 description: Setup Ruby with caching and dependency installation
+inputs:
+  job-name:
+    description: The name of the job that will use this action
+    required: true
 
 runs:
   using: composite
@@ -11,9 +15,10 @@ runs:
       with:
         bundler-cache: true
     - name: Bundle Install with Caching
+      if: ${{ inputs.job-name != 'Minitest' }}
       shell: bash
       working-directory: ./ruby
       run: |
         bundle config set path vendor/bundle
-        bundle install
+        bundle install --with=${{ inputs.job-name }}
         bundle lock --add-checksums

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -81,6 +81,19 @@ jobs:
       - name: Minitest
         working-directory: ./ruby
         run: ruby test/application_test.rb
+  brakeman:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    needs: change-detection
+    if: needs.change-detection.outputs.ruby-changes == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-ruby
+        with:
+          job-name: Brakeman
+      - name: Brakeman
+        working-directory: ./ruby
+        run: brakeman --no-pager
   rubocop:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -76,6 +76,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby
+        with:
+          job-name: Minitest
       - name: Minitest
         working-directory: ./ruby
         run: ruby test/application_test.rb
@@ -87,6 +89,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby
+        with:
+          job-name: RuboCop
       - name: RuboCop
         working-directory: ./ruby
         run: rubocop
@@ -98,6 +102,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby
+        with:
+          job-name: Steep
       - name: Steep
         working-directory: ./ruby
         run: |

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,7 +1,16 @@
 source 'https://rubygems.org'
 
-gem 'rbs-inline', '~> 0.13.0', require: false
-gem 'rubocop', '~> 1.86.1', require: false
-gem 'rubocop-minitest', '~> 0.39.1', require: false
-gem 'rubocop-performance', '~> 1.26.1', require: false
-gem 'steep', '~> 2.0.0', require: false
+group :brakeman do
+  gem 'brakeman', '~> 8.0.4', require: false
+end
+
+group :rubocop do
+  gem 'rubocop', '~> 1.86.1', require: false
+  gem 'rubocop-minitest', '~> 0.39.1', require: false
+  gem 'rubocop-performance', '~> 1.26.1', require: false
+end
+
+group :steep do
+  gem 'rbs-inline', '~> 0.13.0', require: false
+  gem 'steep', '~> 2.0.0', require: false
+end

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -2,6 +2,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    brakeman (8.0.4)
+      racc
     concurrent-ruby (1.3.6)
     csv (3.3.5)
     ffi (1.17.4-x86_64-linux-gnu)
@@ -85,6 +87,7 @@ PLATFORMS
   x86_64-linux-gnu
 
 DEPENDENCIES
+  brakeman (~> 8.0.4)
   rbs-inline (~> 0.13.0)
   rubocop (~> 1.86.1)
   rubocop-minitest (~> 0.39.1)
@@ -93,6 +96,7 @@ DEPENDENCIES
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d


### PR DESCRIPTION
## 1. Problems to Solve

1. Brakeman is missing for code security scanning.
2. Each job install all Gems, but it's highly verbose. Should install only the required gems.

## 2. Commits

- [Control gems to install in reference to job name](https://github.com/hayat01sh1da/json-data-sorters/commit/f3f054d918372cdba39dd4bb285d7d38fd2afa11)
- [Add Brakeman to workflows for code security scanning](https://github.com/hayat01sh1da/json-data-sorters/pull/32/commits/d0dea28b44eb35669986a3d31f103bbcad672be4)
- [Group gems to install by job](https://github.com/hayat01sh1da/json-data-sorters/pull/32/commits/928094f9211871da8f01248c02b1eef412de9abd)