### PR TITLE
[ruby] Add Missing bundle exec Prefix to Commands

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -103,7 +103,7 @@ jobs:
           job-name: Brakeman
       - name: Brakeman
         working-directory: ./ruby
-        run: brakeman --no-pager
+        run: bundle exec brakeman --no-pager
   rubocop:
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -130,5 +130,5 @@ jobs:
       - name: Steep
         working-directory: ./ruby
         run: |
-          rbs-inline --output sig/generated/ .
-          steep check
+          bundle exec rbs-inline --output sig/generated/ .
+          bundle exec steep check


### PR DESCRIPTION
## Summary

Brakeman, RuboCop, rbs-inline and Steep are available via Gemfile and Bundler, so they require `bundle exec` prefix to invoke.