### PR TITLE
[ruby] Migrate from Local to Global Bundle Installation

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -20,6 +20,5 @@ runs:
       working-directory: ./ruby
       run: |
         rm -rf .bundle/**
-        bundle config set --local with ${{ inputs.job-name }}
         bundle install
         bundle lock --add-checksums

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-# Ruby
-ruby/**/vendor/bundle/**
-
 # Python
 python/**/__pycache__/

--- a/ruby/.bundle/config
+++ b/ruby/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_PATH: "vendor/bundle"

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -2,13 +2,8 @@
 
 source 'https://rubygems.org'
 
-group :rubocop do
-  gem 'rubocop', '~> 1.86.1', require: false
-  gem 'rubocop-minitest', '~> 0.39.1', require: false
-  gem 'rubocop-performance', '~> 1.26.1', require: false
-end
-
-group :steep do
-  gem 'rbs-inline', '~> 0.13.0', require: false
-  gem 'steep', '~> 2.0.0', require: false
-end
+gem 'rubocop', '~> 1.86.1', require: false
+gem 'rubocop-minitest', '~> 0.39.1', require: false
+gem 'rubocop-performance', '~> 1.26.1', require: false
+gem 'rbs-inline', '~> 0.13.0', require: false
+gem 'steep', '~> 2.0.0', require: false

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
+gem 'rbs-inline', '~> 0.13.0', require: false
 gem 'rubocop', '~> 1.86.1', require: false
 gem 'rubocop-minitest', '~> 0.39.1', require: false
 gem 'rubocop-performance', '~> 1.26.1', require: false
-gem 'rbs-inline', '~> 0.13.0', require: false
 gem 'steep', '~> 2.0.0', require: false

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -4,7 +4,17 @@ GEM
     ast (2.4.3)
     concurrent-ruby (1.3.6)
     csv (3.3.5)
+    ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86-linux-musl)
+    ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
     fileutils (1.8.0)
     json (2.19.4)
     language_server-protocol (3.17.0.5)
@@ -82,7 +92,17 @@ GEM
     uri (1.1.1)
 
 PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
   x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   rbs-inline (~> 0.13.0)
@@ -95,7 +115,17 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
+  ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
+  ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
+  ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
+  ffi (1.17.4-arm-linux-musl) sha256=9d4838ded0465bef6e2426935f6bcc93134b6616785a84ffd2a3d82bc3cf6f95
+  ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
+  ffi (1.17.4-x86-linux-gnu) sha256=38e150df5f4ca555e25beca4090823ae09657bceded154e3c52f8631c1ed72cf
+  ffi (1.17.4-x86-linux-musl) sha256=fbeec0fc7c795bcf86f623bb18d31ea1820f7bd580e1703a3d3740d527437809
+  ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
+  ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
   json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -5,7 +5,6 @@
 ## 2. Install Gems via Gemfile and Bundler
 
 ```command
-$ bundle config set --local path vendor/bundle
 $ bundle install
 $ bundle lock --add-checksums
 ```


### PR DESCRIPTION
## Summary

Local Gem installation often disables Bundler to find commands, particularly a Gem is installed both globally and locally.
Only global Gem installation makes fewer confusions, so `bundle config set --local path vendor/bundle` should be aborted.

Besides, grouping on Gemfile makes no effects on GitHub Actions efficiency because of bundler-cache, so it also should be discarded.