### PR TITLE
[REVERT][ruby] Stop Managing Signature Files

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -117,5 +117,4 @@ jobs:
       - name: Steep
         working-directory: ./ruby
         run: |
-          bundle exec rbs-inline --output sig/generated/ .
           bundle exec steep check

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-# Ruby
-ruby/sig/
-
 # Python
 python/**/__pycache__/

--- a/ruby/sig/generated/main.rbs
+++ b/ruby/sig/generated/main.rbs
@@ -1,0 +1,2 @@
+# Generated from main.rb with RBS::Inline
+

--- a/ruby/sig/generated/src/application.rbs
+++ b/ruby/sig/generated/src/application.rbs
@@ -1,0 +1,59 @@
+# Generated from src/application.rb with RBS::Inline
+
+class Application
+  class InvalidFilenameError < StandardError
+  end
+
+  class InvalidOrderError < StandardError
+  end
+
+  # @rbs dirname: String
+  # @rbs filename: String
+  # @rbs order: untyped
+  # @rbs return: void
+  def self.run: (?dirname: String, ?filename: String, ?order: untyped) -> void
+
+  # @rbs dirname: String
+  # @rbs filename: String
+  # @rbs order: untyped
+  # ⚠️ `order` expects a class which can be converted to Symbol by `to_sym` method(e.g. String, Symbol).
+  # ⚠️ Otherwise, it will raise an error when validating order.
+  # @rbs return: void
+  def initialize: (?dirname: String, ?filename: String, ?order: untyped) -> void
+
+  # @rbs return: String
+  def validate_filename!: () -> String
+
+  # @rbs return: Symbol
+  def validate_order!: () -> Symbol
+
+  # @rbs return: void
+  def run: () -> void
+
+  private
+
+  attr_reader dirname: untyped
+
+  attr_reader filename: untyped
+
+  attr_reader filepath: untyped
+
+  attr_reader order: untyped
+
+  # @rbs return: Hash[String, untyped]?
+  def json_data: () -> Hash[String, untyped]?
+
+  # @rbs return: Hash[String, untyped]?
+  def converted_json_data_with_sorting: () -> Hash[String, untyped]?
+
+  # @rbs hash: Hash[String, untyped]
+  # @rbs return: String
+  def dump_converted_json_data_with_sorting: (?Hash[String, untyped] hash) -> String
+
+  # @rbs return: bool
+  def test_env?: () -> bool
+
+  # @rbs message: String
+  # @rbs return: void
+  def output: (String message) -> void
+end

--- a/ruby/sig/generated/test/application_test.rbs
+++ b/ruby/sig/generated/test/application_test.rbs
@@ -1,0 +1,36 @@
+# Generated from test/application_test.rb with RBS::Inline
+
+class ApplicationTest < Minitest::Test
+  def setup: () -> untyped
+
+  def teardown: () -> untyped
+
+  def test_sort_json_data_by_asc: () -> untyped
+
+  def test_sort_json_data_by_desc: () -> untyped
+
+  def test_sort_json_data_with_no_filename: () -> untyped
+
+  def test_sort_json_data_with_invalid_order_type: () -> untyped
+
+  def test_sort_json_data_with_invalid_data_type_of_order: () -> untyped
+
+  private
+
+  attr_reader dirname: untyped
+
+  attr_reader filename: untyped
+
+  attr_reader filepath: untyped
+
+  def actual_json: () -> untyped
+
+  def json_data: () -> untyped
+
+  # Conf. https://7esl.com/english-names/
+  def user_data: () -> untyped
+
+  def sorted_user_data_by_asc: () -> untyped
+
+  def sorted_user_data_by_desc: () -> untyped
+end

--- a/ruby/sig/generated/test/helper/symbolize_helper.rbs
+++ b/ruby/sig/generated/test/helper/symbolize_helper.rbs
@@ -1,0 +1,13 @@
+# Generated from test/helper/symbolize_helper.rb with RBS::Inline
+
+module SymbolizeHelper
+  # @rbs h: Hash[untyped, untyped]
+  # @rbs return: Hash[untyped, untyped]
+  def self.symbolize_recursive: (untyped hash, ?untyped hsh) -> Hash[untyped, untyped]
+
+  # @rbs return: untyped
+  def self.transform: (untyped object) -> untyped
+
+  # @rbs return: Hash[Symbol, untyped]
+  def deep_symbolize_keys: () -> Hash[Symbol, untyped]
+end


### PR DESCRIPTION
## 1. Target PR to Revert

- https://github.com/hayat01sh1da/json-data-sorters/pull/38

## 2. Context

Acccording to the article shown below, signrature files should be hosted and ought not to be generated in GitHub Actions workflow because they should be static on a repository.
That is why, `bundle exec rbs-inline --output sig/generated/ .` has been aborted since it generates new signature files and can make differences.

## 3. Reference

- [Rails アプリケーション型付けハンドブック(rbs/steep) > Chapter 04 自前で定義したメソッドの型シグネチャの導入 > 4.4. rbs-inline での出力](https://zenn.dev/sanfrecce_osaka/books/steep-rails-typing-handbook/viewer/introduce-type-signature-for-handwritten-method#4.4.-rbs-inline-での出力)