### PR TITLE
[ruby] Remove Needless FileUtils Import from Codebase

### DIFF
--- a/ruby/src/application.rb
+++ b/ruby/src/application.rb
@@ -1,7 +1,6 @@
 # rbs_inline: enabled
 
 require 'json'
-require 'fileutils'
 
 class Application
   class InvalidFilenameError < StandardError; end


### PR DESCRIPTION
## Summary

`FileUtils` used to needRuby code to require it with `require 'fileutils'`; however, it has no effect on behaviours.
That is to say, any Ruby script works without it.

⚠️ Steep requires `Steepfile` to declare `library 'fileutils'`; otherwise, type checking fails.