### PR TITLE
[ruby] Transfer Ruby CI Workflow to Bundle Execution with Rakefile

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -90,7 +90,7 @@ jobs:
           job-name: minitest
       - name: Minitest
         working-directory: ./ruby
-        run: ruby test/application_test.rb
+        run: rake
   rubocop:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -27,14 +27,14 @@ Done export JSON data in ./json/settings.json 🎉
 ## 4. Unit Test
 
 ```command
-$ ruby test/application_test.rb 
-Run options: --seed 44849
+$ rake
+Run options: --seed 65057
 
 # Running:
 
 .....
 
-Finished in 0.106035s, 47.1541 runs/s, 75.4466 assertions/s.
+Finished in 0.203643s, 24.5528 runs/s, 39.2845 assertions/s.
 
 5 runs, 8 assertions, 0 failures, 0 errors, 0 skips
 ```

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake/testtask'
 task default: :test
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,0 +1,6 @@
+require 'rake/testtask'
+task default: :test
+
+Rake::TestTask.new do |task|
+  task.pattern = File.join('.', '**', '*_test.rb')
+end


### PR DESCRIPTION
## Summary

To Guarantee idempotency, it switched to Minitest CI from single file to bulk execution.