### PR TITLE
[ruby] Amend README

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -12,7 +12,6 @@ $ bundle lock --add-checksums
 ## 3. Execution
 
 ```command
-$ cd ./ruby
 $ ruby main.rb
 Provide the directory name you put the JSON file in:
 ../json


### PR DESCRIPTION
## Summary

The path to execute the script is self-evident, so omit the description of `cd ruby/`.