### PR TITLE
[python] Migrate to pytest

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -74,7 +74,7 @@ jobs:
       - uses: ./.github/actions/setup-python
       - name: UnitTest
         working-directory: ./python
-        run: python -m unittest discover ./test
+        run: pytest
   mypy:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/python/README.md
+++ b/python/README.md
@@ -2,14 +2,33 @@
 
 - Python 3.14.4
 
-## 2. Execution
+## 2. Install Libraries via requirements.txt
 
 ```command
-$ cd ./python
+$ pip install -r requirements.txt
+```
+
+## 3. Execution
+
+```command
 $ python main.py
 Provide the directory name you put the JSON file in: ../json
 Provide the filename of which JSON data name you would like to sort: settings.json
 Provide asc(default) or desc you would like to sort key-value in: asc
 Start exporting JSON data in ./json/settings.json
 Done exporting JSON data in ./json/settings.json 🎉
+```
+
+## 4. Unit Test
+
+```command
+$ pytest 
+============================= test session starts ==============================
+platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
+rootdir: /mnt/c/Users/binlh/Documents/development/json-data-sorters/python
+collected 5 items
+
+test/test_application.py .....                                           [100%]
+
+============================== 5 passed in 0.26s ===============================
 ```


### PR DESCRIPTION
## 1. Overview

Pytest is superior to Python’s built-in unittest (and its discover capability) primarily due to its minimal boilerplate code, advanced fixture system for dependency management, and highly readable, simple assert statements.  
It offers superior test discovery, robust plugin support, parameterization, and faster execution via parallel testing.

## 2. Benefits

- **Less Verbose (No Classes Required)**: Pytest allows you to write simple functions to test, whereas `unittest `forces you to organize tests inside classes inheriting from `unittest.TestCase`
- **Simple Assertions**: Instead of `self.assertEqual(a, b)`, you just use Python’s native `assert a == b`. Pytest provides detailed inspection of failed assertions, showing you exactly what went wrong without needing manual error messages
- **Powerful Fixtures**: Pytest’s fixture system is far more modular, scalable, and easier to use for `setup/teardown` than unittest's `setUp/tearDown` methods
- **Parameterization**: Pytest makes it simple to run the same test with different input values using `@pytest.mark.parametrize`, reducing code duplication
- **Massive Plugin Ecosystem**: With hundreds of plugins (e.g., `pytest-cov`, `pytest-django`, `pytest-asyncio`), it is highly extensible, while unittest is limited to built-in functionality
- **Better Test Discovery and Selection**: While `discover `works, `pytest `offers more powerful, intuitive filtering to run specific subsets of tests (by name, marker, or directory)
- **Faster Execution**: Pytest supports running tests in parallel, significantly reducing testing time for large projects

## 3. Summary

In summary, pytest is preferred for its "simple, rapid and fun" approach, significantly reducing the maintenance burden of your test suite.