### PR TITLE
[python] Execute Lint Fixes

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -1,22 +1,26 @@
+from application import Application
 import sys
 import os
 import shutil
 import glob
 sys.path.append('./src')
-from application import Application
 
-dirname  = input('Provide the directory name you put the JSON file in: ').strip()
-filename = input('Provide the filename of which JSON data name you would like to sort: ').strip()
-order    = input('Provide asc(default) or desc you would like to sort key-value in: ').strip()
+dirname = input(
+    'Provide the directory name you put the JSON file in: ').strip()
+filename = input(
+    'Provide the filename of which JSON data name you would like to sort: ').strip()
+order = input(
+    'Provide asc(default) or desc you would like to sort key-value in: ').strip()
 
 params = dict()
-for key, value in { 'dirname': dirname, 'filename': filename, 'order': order }.items():
+for key, value in {'dirname': dirname,
+                   'filename': filename, 'order': order}.items():
     if value:
         params[key] = value
 
 Application(**params).run()
 
-pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True)
 for pycache in pycaches:
     if os.path.exists(pycache):
         shutil.rmtree(pycache)

--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -1,8 +1,11 @@
+ast_serialize==0.3.0
+autoflake8==0.4.1
+autopep8==2.3.2
 flake8==7.3.0
 iniconfig==2.3.0
-librt==0.9.0
+librt==0.10.0
 mccabe==0.7.0
-mypy==1.20.2
+mypy==2.0.0
 mypy_extensions==1.1.0
 packaging==26.2
 pathspec==1.1.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,5 @@
+autoflake8==0.4.1
+autopep8==2.3.2
 flake8==7.3.0
-mypy==1.20.2
+mypy==2.0.0
 pytest==9.0.3

--- a/python/src/application.py
+++ b/python/src/application.py
@@ -2,14 +2,17 @@ import os
 import json
 import inspect
 
+
 class InvalidFilenameError(Exception):
     pass
+
 
 class InvalidOrderError(Exception):
     pass
 
+
 class Application:
-    def __init__(self, dirname, filename, order = 'asc'):
+    def __init__(self, dirname, filename, order='asc'):
         self.dirname = dirname
         if len(filename) == 0:
             raise InvalidFilenameError('Filename must be provided.')
@@ -20,11 +23,13 @@ class Application:
         if not (order == 'asc' or order == 'desc'):
             raise InvalidOrderError('Order option must be either asc or desc.')
         self.order = order
-        self.env   = inspect.stack()[1].filename.split('/')[-2]
+        self.env = inspect.stack()[1].filename.split('/')[-2]
 
     def run(self):
-        self.__output__('Start exporting JSON data in {filepath}'.format(filepath = self.filepath))
-        os.makedirs(self.dirname, exist_ok = True)
+        self.__output__(
+            'Start exporting JSON data in {filepath}'.format(
+                filepath=self.filepath))
+        os.makedirs(self.dirname, exist_ok=True)
         if not os.path.isfile(self.filepath):
             with open(self.filepath, 'w') as f:
                 f.write('')
@@ -34,7 +39,9 @@ class Application:
         except json.decoder.JSONDecodeError:
             with open(self.filepath, 'a') as f:
                 f.write('')
-        self.__output__('Done exporting JSON data in {filepath} 🎉'.format(filepath = self.filepath))
+        self.__output__(
+            'Done exporting JSON data in {filepath} 🎉'.format(
+                filepath=self.filepath))
 
     # private
 
@@ -46,22 +53,33 @@ class Application:
         return json_data
 
     def __sorted_json_data__(self):
-        return dict(sorted(self.__json_data__().items())) if self.order == 'asc' else dict(sorted(self.__json_data__().items(), reverse = True))
+        return dict(
+            sorted(
+                self.__json_data__().items())) if self.order == 'asc' else dict(
+            sorted(
+                self.__json_data__().items(),
+                reverse=True))
 
     def __dump_sorted_json_data__(self):
         dictionary = {}
         for key, value in self.__sorted_json_data__().items():
             if isinstance(value, dict):
-                dictionary[key] = dict(sorted(value.items())) if self.order == 'asc' else dict(sorted(value.items(), reverse = True))
+                dictionary[key] = dict(
+                    sorted(
+                        value.items())) if self.order == 'asc' else dict(
+                    sorted(
+                        value.items(),
+                        reverse=True))
             elif isinstance(value, list):
-                dictionary[key] = sorted(value) if self.order == 'asc' else sorted(value, reverse = True)
+                dictionary[key] = sorted(
+                    value) if self.order == 'asc' else sorted(value, reverse=True)
             else:
                 dictionary[key] = value
-        return json.dumps(dictionary, ensure_ascii = False, indent = 2)
+        return json.dumps(dictionary, ensure_ascii=False, indent=2)
 
     def __is_test_env__(self):
         """Check if running in a test environment.
-        
+
         Returns:
             bool: True if in test environment, False otherwise.
         """

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -1,4 +1,3 @@
-from application import Application, InvalidFilenameError, InvalidOrderError
 import json
 import unittest
 import os
@@ -6,6 +5,7 @@ import glob
 import shutil
 import sys
 sys.path.append('./src')
+from application import Application, InvalidFilenameError, InvalidOrderError
 
 
 class TestApplication(unittest.TestCase):

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -1,21 +1,27 @@
+from application import Application, InvalidFilenameError, InvalidOrderError
+import json
 import unittest
 import os
 import glob
 import shutil
 import sys
 sys.path.append('./src')
-import json
-from application import Application, InvalidFilenameError, InvalidOrderError
+
 
 class TestApplication(unittest.TestCase):
     def setUp(self):
-        self.dirname  = os.path.join('.', 'test', 'tmp')
+        self.dirname = os.path.join('.', 'test', 'tmp')
         self.filename = 'users.json'
         self.filepath = os.path.join(self.dirname, self.filename)
-        os.makedirs(self.dirname, exist_ok = True)
+        os.makedirs(self.dirname, exist_ok=True)
         with open(self.filepath, 'w') as f:
             f.write(self.__json_data__())
-        self.pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+        self.pycaches = glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True)
 
     def tearDown(self):
         if os.path.exists(self.dirname):
@@ -27,28 +33,43 @@ class TestApplication(unittest.TestCase):
     ########## Regular Cases ##########
 
     def test_sort_json_data_by_asc(self):
-        Application(dirname = self.dirname, filename = self.filename).run()
-        self.assertEqual(self.__actual_json__(), self.__sorted_user_data_by_asc__())
+        Application(dirname=self.dirname, filename=self.filename).run()
+        self.assertEqual(
+            self.__actual_json__(),
+            self.__sorted_user_data_by_asc__())
 
     def test_sort_json_data_by_desc(self):
-        Application(dirname = self.dirname, filename = self.filename, order = 'desc').run()
-        self.assertEqual(self.__actual_json__(), self.__sorted_user_data_by_desc__())
+        Application(
+            dirname=self.dirname,
+            filename=self.filename,
+            order='desc').run()
+        self.assertEqual(
+            self.__actual_json__(),
+            self.__sorted_user_data_by_desc__())
 
     ########## Irregular Cases ##########
 
     def test_sort_json_data_with_missing_filename(self):
         with self.assertRaises(InvalidFilenameError) as cm:
-            Application(dirname = self.dirname, filename = '').run()
+            Application(dirname=self.dirname, filename='').run()
         self.assertEqual('Filename must be provided.', str(cm.exception))
 
     def test_sort_json_data_with_invalid_order(self):
         with self.assertRaises(InvalidOrderError) as cm:
-            Application(dirname = self.dirname, filename = self.filename, order = 'hoge').run()
-        self.assertEqual('Order option must be either asc or desc.', str(cm.exception))
+            Application(
+                dirname=self.dirname,
+                filename=self.filename,
+                order='hoge').run()
+        self.assertEqual(
+            'Order option must be either asc or desc.', str(
+                cm.exception))
 
     def test_sort_json_data_with_non_string_order(self):
         with self.assertRaises(InvalidOrderError) as cm:
-            Application(dirname = self.dirname, filename = self.filename, order = 1).run()
+            Application(
+                dirname=self.dirname,
+                filename=self.filename,
+                order=1).run()
         self.assertEqual('Unexpected param was provided', str(cm.exception))
 
     # private
@@ -61,7 +82,7 @@ class TestApplication(unittest.TestCase):
         return json_data
 
     def __json_data__(self):
-        return json.dumps(self.__user_data__(), ensure_ascii = False, indent = 2)
+        return json.dumps(self.__user_data__(), ensure_ascii=False, indent=2)
 
     def __user_data__(self):
         return {
@@ -236,6 +257,7 @@ class TestApplication(unittest.TestCase):
                 'age': 35
             }
         }
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 1. Overview

This project makes use of [flake8](https://pypi.org/project/flake8/) as an inspector of violations against Python syntax and convention.
However, it does not fix them, so some other libraries need installing, which are [autoflake8](https://pypi.org/project/autoflake8/) and [autopep8](https://pypi.org/project/autopep8/)

## 2. Commit

- [nstall lint-fix library and update dependencies](https://github.com/hayat01sh1da/json-data-sorters/commit/0f9e0aefe48c7a02afe3a6b8baaed83de18dd237)
- [Execute lint fixed with autopep8](https://github.com/hayat01sh1da/json-data-sorters/commit/1f7837fe3e3239c72ae106e99d496ab9af832f34)
- [Move module imports to the top of the file in order to comply with PEP 8 guidelines](https://github.com/hayat01sh1da/json-data-sorters/pull/51/changes/cf29dec24cff4e5df195d5bd192bdde19584cd67)