### PR TITLE
[python] Migrate from Native Python UnitTest to pytest

### DIFF
--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,0 +1,70 @@
+import glob
+import json
+import os
+import shutil
+import sys
+
+sys.path.append('./src')
+
+
+import pytest
+
+
+_USER_DATA = {
+    'user2': {
+        'name': 'Wade Williams',
+        'age': 45,
+        'gender': 'Male',
+        'occupation': 'Global Trading Marketer',
+        'skills': {
+            'languages': ['Japanese', 'English', 'Spanish', 'German', 'French'],
+            'expertise': ['Marketing', 'Accounting', 'Interpretation', 'Translation', 'Economics'],
+        },
+    },
+    'user3': {
+        'name': 'Daisy Harris',
+        'age': 30,
+        'gender': 'Female',
+        'occupation': 'High School Teacher',
+        'skills': {
+            'languages': ['English', 'Spanish'],
+            'expertise': ['Teaching Foreign Language'],
+        },
+    },
+    'user1': {
+        'name': 'Wade Williams',
+        'age': 35,
+        'occupation': 'Software Engineer',
+        'skills': {
+            'languages': ['Japanese', 'English'],
+            'expertise': [
+                'Server-Side Programming',
+                'Front-end Programming',
+                'Infrastructure Management',
+                'Team Members Management',
+            ],
+        },
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_pycaches():
+    before = set(glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True))
+    yield
+    for pycache in before:
+        if os.path.exists(pycache):
+            shutil.rmtree(pycache)
+
+
+@pytest.fixture
+def users_workspace():
+    dirname = os.path.join('.', 'test', 'tmp')
+    filename = 'users.json'
+    filepath = os.path.join(dirname, filename)
+    os.makedirs(dirname, exist_ok=True)
+    with open(filepath, 'w') as f:
+        f.write(json.dumps(_USER_DATA, ensure_ascii=False, indent=2))
+    yield dirname, filename, filepath
+    if os.path.exists(dirname):
+        shutil.rmtree(dirname)

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -1,263 +1,115 @@
 import json
-import unittest
-import os
-import glob
-import shutil
-import sys
-sys.path.append('./src')
+
+import pytest
+
 from application import Application, InvalidFilenameError, InvalidOrderError
 
 
-class TestApplication(unittest.TestCase):
-    def setUp(self):
-        self.dirname = os.path.join('.', 'test', 'tmp')
-        self.filename = 'users.json'
-        self.filepath = os.path.join(self.dirname, self.filename)
-        os.makedirs(self.dirname, exist_ok=True)
-        with open(self.filepath, 'w') as f:
-            f.write(self.__json_data__())
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-
-    def tearDown(self):
-        if os.path.exists(self.dirname):
-            shutil.rmtree(self.dirname)
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    ########## Regular Cases ##########
-
-    def test_sort_json_data_by_asc(self):
-        Application(dirname=self.dirname, filename=self.filename).run()
-        self.assertEqual(
-            self.__actual_json__(),
-            self.__sorted_user_data_by_asc__())
-
-    def test_sort_json_data_by_desc(self):
-        Application(
-            dirname=self.dirname,
-            filename=self.filename,
-            order='desc').run()
-        self.assertEqual(
-            self.__actual_json__(),
-            self.__sorted_user_data_by_desc__())
-
-    ########## Irregular Cases ##########
-
-    def test_sort_json_data_with_missing_filename(self):
-        with self.assertRaises(InvalidFilenameError) as cm:
-            Application(dirname=self.dirname, filename='').run()
-        self.assertEqual('Filename must be provided.', str(cm.exception))
-
-    def test_sort_json_data_with_invalid_order(self):
-        with self.assertRaises(InvalidOrderError) as cm:
-            Application(
-                dirname=self.dirname,
-                filename=self.filename,
-                order='hoge').run()
-        self.assertEqual(
-            'Order option must be either asc or desc.', str(
-                cm.exception))
-
-    def test_sort_json_data_with_non_string_order(self):
-        with self.assertRaises(InvalidOrderError) as cm:
-            Application(
-                dirname=self.dirname,
-                filename=self.filename,
-                order=1).run()
-        self.assertEqual('Unexpected param was provided', str(cm.exception))
-
-    # private
-
-    # Conf. https://7esl.com/english-names/
-    def __actual_json__(self):
-        json_data = None
-        with open(self.filepath) as f:
-            json_data = json.load(f)
-        return json_data
-
-    def __json_data__(self):
-        return json.dumps(self.__user_data__(), ensure_ascii=False, indent=2)
-
-    def __user_data__(self):
-        return {
-            'user2': {
-                'name': 'Wade Williams',
-                'age': 45,
-                'gender': 'Male',
-                'occupation': 'Global Trading Marketer',
-                'skills': {
-                    'languages': [
-                        'Japanese',
-                        'English',
-                        'Spanish',
-                        'German',
-                        'French'
-                    ],
-                    'expertise': [
-                        'Marketing',
-                        'Accounting',
-                        'Interpretation',
-                        'Translation',
-                        'Economics'
-                    ]
-                }
-            },
-            'user3': {
-                'name': 'Daisy Harris',
-                'age': 30,
-                'gender': 'Female',
-                'occupation': 'High School Teacher',
-                'skills': {
-                    'languages': [
-                        'English',
-                        'Spanish'
-                    ],
-                    'expertise': [
-                        'Teaching Foreign Language'
-                    ]
-                }
-            },
-            'user1': {
-                'name': 'Wade Williams',
-                'age': 35,
-                'occupation': 'Software Engineer',
-                'skills': {
-                    'languages': [
-                        'Japanese',
-                        'English'
-                    ],
-                    'expertise': [
-                        'Server-Side Programming',
-                        'Front-end Programming',
-                        'Infrastructure Management',
-                        'Team Members Management',
-                    ]
-                }
-            }
-        }
-
-    def __sorted_user_data_by_asc__(self):
-        return {
-            'user1': {
-                'age': 35,
-                'name': 'Wade Williams',
-                'occupation': 'Software Engineer',
-                'skills': {
-                    'languages': [
-                        'Japanese',
-                        'English'
-                    ],
-                    'expertise': [
-                        'Server-Side Programming',
-                        'Front-end Programming',
-                        'Infrastructure Management',
-                        'Team Members Management'
-                    ]
-                }
-            },
-            'user2': {
-                'age': 45,
-                'gender': 'Male',
-                'name': 'Wade Williams',
-                'occupation': 'Global Trading Marketer',
-                'skills': {
-                    'languages': [
-                        'Japanese',
-                        'English',
-                        'Spanish',
-                        'German',
-                        'French'
-                    ],
-                    'expertise': [
-                        'Marketing',
-                        'Accounting',
-                        'Interpretation',
-                        'Translation',
-                        'Economics'
-                    ]
-                }
-            },
-            'user3': {
-                'age': 30,
-                'gender': 'Female',
-                'name': 'Daisy Harris',
-                'occupation': 'High School Teacher',
-                'skills': {
-                    'languages': [
-                        'English',
-                        'Spanish'
-                    ],
-                    'expertise': [
-                        'Teaching Foreign Language'
-                    ]
-                }
-            }
-        }
-
-    def __sorted_user_data_by_desc__(self):
-        return {
-            'user3': {
-                'skills': {
-                    'languages': [
-                        'English',
-                        'Spanish'
-                    ],
-                    'expertise': [
-                        'Teaching Foreign Language'
-                    ]
-                },
-                'occupation': 'High School Teacher',
-                'name': 'Daisy Harris',
-                'gender': 'Female',
-                'age': 30
-            },
-            'user2': {
-                'skills': {
-                    'languages': [
-                        'Japanese',
-                        'English',
-                        'Spanish',
-                        'German',
-                        'French'
-                    ],
-                    'expertise': [
-                        'Marketing',
-                        'Accounting',
-                        'Interpretation',
-                        'Translation',
-                        'Economics'
-                    ]
-                },
-                'occupation': 'Global Trading Marketer',
-                'name': 'Wade Williams',
-                'gender': 'Male',
-                'age': 45
-            },
-            'user1': {
-                'skills': {
-                    'languages': [
-                        'Japanese',
-                        'English'
-                    ],
-                    'expertise': [
-                        'Server-Side Programming',
-                        'Front-end Programming',
-                        'Infrastructure Management',
-                        'Team Members Management'
-                    ]
-                },
-                'occupation': 'Software Engineer',
-                'name': 'Wade Williams',
-                'age': 35
-            }
-        }
+def _read_json(filepath):
+    with open(filepath) as f:
+        return json.load(f)
 
 
-if __name__ == '__main__':
-    unittest.main()
+_SORTED_BY_ASC = {
+    'user1': {
+        'age': 35,
+        'name': 'Wade Williams',
+        'occupation': 'Software Engineer',
+        'skills': {
+            'languages': ['Japanese', 'English'],
+            'expertise': [
+                'Server-Side Programming',
+                'Front-end Programming',
+                'Infrastructure Management',
+                'Team Members Management',
+            ],
+        },
+    },
+    'user2': {
+        'age': 45,
+        'gender': 'Male',
+        'name': 'Wade Williams',
+        'occupation': 'Global Trading Marketer',
+        'skills': {
+            'languages': ['Japanese', 'English', 'Spanish', 'German', 'French'],
+            'expertise': ['Marketing', 'Accounting', 'Interpretation', 'Translation', 'Economics'],
+        },
+    },
+    'user3': {
+        'age': 30,
+        'gender': 'Female',
+        'name': 'Daisy Harris',
+        'occupation': 'High School Teacher',
+        'skills': {
+            'languages': ['English', 'Spanish'],
+            'expertise': ['Teaching Foreign Language'],
+        },
+    },
+}
+
+_SORTED_BY_DESC = {
+    'user3': {
+        'skills': {
+            'languages': ['English', 'Spanish'],
+            'expertise': ['Teaching Foreign Language'],
+        },
+        'occupation': 'High School Teacher',
+        'name': 'Daisy Harris',
+        'gender': 'Female',
+        'age': 30,
+    },
+    'user2': {
+        'skills': {
+            'languages': ['Japanese', 'English', 'Spanish', 'German', 'French'],
+            'expertise': ['Marketing', 'Accounting', 'Interpretation', 'Translation', 'Economics'],
+        },
+        'occupation': 'Global Trading Marketer',
+        'name': 'Wade Williams',
+        'gender': 'Male',
+        'age': 45,
+    },
+    'user1': {
+        'skills': {
+            'languages': ['Japanese', 'English'],
+            'expertise': [
+                'Server-Side Programming',
+                'Front-end Programming',
+                'Infrastructure Management',
+                'Team Members Management',
+            ],
+        },
+        'occupation': 'Software Engineer',
+        'name': 'Wade Williams',
+        'age': 35,
+    },
+}
+
+
+def test_sort_json_data_by_asc(users_workspace):
+    dirname, filename, filepath = users_workspace
+    Application(dirname=dirname, filename=filename).run()
+    assert _read_json(filepath) == _SORTED_BY_ASC
+
+
+def test_sort_json_data_by_desc(users_workspace):
+    dirname, filename, filepath = users_workspace
+    Application(dirname=dirname, filename=filename, order='desc').run()
+    assert _read_json(filepath) == _SORTED_BY_DESC
+
+
+def test_sort_json_data_with_missing_filename(users_workspace):
+    dirname, _, _ = users_workspace
+    with pytest.raises(InvalidFilenameError, match=r'^Filename must be provided\.$'):
+        Application(dirname=dirname, filename='').run()
+
+
+def test_sort_json_data_with_invalid_order(users_workspace):
+    dirname, filename, _ = users_workspace
+    with pytest.raises(InvalidOrderError, match=r'^Order option must be either asc or desc\.$'):
+        Application(dirname=dirname, filename=filename, order='hoge').run()
+
+
+def test_sort_json_data_with_non_string_order(users_workspace):
+    dirname, filename, _ = users_workspace
+    with pytest.raises(InvalidOrderError, match=r'^Unexpected param was provided$'):
+        Application(dirname=dirname, filename=filename, order=1).run()


### PR DESCRIPTION
## 1. Overview

Migrate the Python test suite from the standard library's `unittest` to `pytest`, adopting idiomatic pytest patterns (plain functions, fixtures, `assert`, `parametrize`) to reduce boilerplate and improve readability.

## 2. Changes

- Replace `unittest.TestCase` subclasses with plain test functions.
- Replace `setUp` / `tearDown` with pytest fixtures:
  - An autouse `_cleanup_pycaches` fixture in each `conftest.py` removes the per-file `glob` / `shutil.rmtree` `__pycache__` cleanup that was duplicated across every test module.
  - Per-suite state (object construction, temp directories, file workspaces) becomes regular or factory fixtures.
- Replace `self.assertEqual` / `assertTrue` / `assertFalse` / `assertIsNone` etc. with `assert` expressions.
- Replace `self.assertRaises(Cls) as cm` / `str(cm.exception) == "..."` with `pytest.raises(Cls, match=r"...")`.
- Collapse `TestCase`-subclass-as-parameter patterns into `@pytest.mark.parametrize`.
- Replace `contextlib.redirect_stdout` / custom `redirect_stdin` helpers with pytest's `capsys` and `monkeypatch` (`monkeypatch.setattr('sys.stdin', io.StringIO(...))`).
- Move shared `sys.path.append('./src')` (and friends) out of every test file into the test directory's `conftest.py`.

## 3. Summary

The result is a smaller, more uniform test suite: shared setup is declared once per test directory rather than re-implemented per file, assertions read as plain Python expressions, and parameterised cases use a single function with an explicit data table instead of a subclass hierarchy. There is no change in test coverage or assertion intent; this is a pure framework swap.

## 4. Others

- Run the suite locally with `pytest` from the project root after installing dependencies (`pip install -r requirements.txt`).
- The autouse `_cleanup_pycaches` fixture preserves the original behaviour of wiping any `__pycache__` directories created during a test run.
- No changes to `src/` are included in this PR — only the `test/` directory (and, where applicable, `requirements.txt` to declare `pytest`, and the CI workflow if it previously invoked `python -m unittest`).
