### PR TITLE
[python] Install Type Checking

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.mypy]
+python_version = "3.14"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true

--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -1,9 +1,9 @@
-ast_serialize==0.3.0
+ast_serialize==0.5.0
 autoflake8==0.4.1
 autopep8==2.3.2
 flake8==7.3.0
 iniconfig==2.3.0
-librt==0.10.0
+librt==0.11.0
 mccabe==0.7.0
 mypy==2.0.0
 mypy_extensions==1.1.0

--- a/python/src/application.py
+++ b/python/src/application.py
@@ -12,7 +12,8 @@ class InvalidOrderError(Exception):
 
 
 class Application:
-    def __init__(self, dirname, filename, order='asc'):
+    def __init__(self, dirname: str, filename: str,
+                 order: str = 'asc') -> None:
         self.dirname = dirname
         if len(filename) == 0:
             raise InvalidFilenameError('Filename must be provided.')
@@ -25,7 +26,7 @@ class Application:
         self.order = order
         self.env = inspect.stack()[1].filename.split('/')[-2]
 
-    def run(self):
+    def run(self) -> None:
         self.__output__(
             'Start exporting JSON data in {filepath}'.format(
                 filepath=self.filepath))
@@ -45,14 +46,14 @@ class Application:
 
     # private
 
-    def __json_data__(self):
-        json_data = None
+    def __json_data__(self) -> dict[str, dict | str | int | bool]:
+        json_data: dict[str, dict | str | int | bool] = {}
         with open(self.filepath, 'r+') as f:
             json_data = json.load(f)
             f.truncate(0)
         return json_data
 
-    def __sorted_json_data__(self):
+    def __sorted_json_data__(self) -> dict[str, dict | str | int | bool]:
         return dict(
             sorted(
                 self.__json_data__().items())) if self.order == 'asc' else dict(
@@ -60,8 +61,8 @@ class Application:
                 self.__json_data__().items(),
                 reverse=True))
 
-    def __dump_sorted_json_data__(self):
-        dictionary = {}
+    def __dump_sorted_json_data__(self) -> str:
+        dictionary: dict[str, dict | str | int | bool] = {}
         for key, value in self.__sorted_json_data__().items():
             if isinstance(value, dict):
                 dictionary[key] = dict(
@@ -77,7 +78,7 @@ class Application:
                 dictionary[key] = value
         return json.dumps(dictionary, ensure_ascii=False, indent=2)
 
-    def __is_test_env__(self):
+    def __is_test_env__(self) -> bool:
         """Check if running in a test environment.
 
         Returns:
@@ -85,7 +86,7 @@ class Application:
         """
         return self.env == 'test'
 
-    def __output__(self, message):
+    def __output__(self, message: str) -> None:
         """Output a message if not running in the test environment.
 
         Args:

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,13 +1,12 @@
+import pytest
 import glob
 import json
 import os
 import shutil
 import sys
+from collections.abc import Iterator
 
 sys.path.append('./src')
-
-
-import pytest
 
 
 _USER_DATA = {
@@ -17,8 +16,18 @@ _USER_DATA = {
         'gender': 'Male',
         'occupation': 'Global Trading Marketer',
         'skills': {
-            'languages': ['Japanese', 'English', 'Spanish', 'German', 'French'],
-            'expertise': ['Marketing', 'Accounting', 'Interpretation', 'Translation', 'Economics'],
+            'languages': [
+                'Japanese',
+                'English',
+                'Spanish',
+                'German',
+                'French'],
+            'expertise': [
+                'Marketing',
+                'Accounting',
+                'Interpretation',
+                'Translation',
+                'Economics'],
         },
     },
     'user3': {
@@ -27,7 +36,9 @@ _USER_DATA = {
         'gender': 'Female',
         'occupation': 'High School Teacher',
         'skills': {
-            'languages': ['English', 'Spanish'],
+            'languages': [
+                'English',
+                'Spanish'],
             'expertise': ['Teaching Foreign Language'],
         },
     },
@@ -36,7 +47,9 @@ _USER_DATA = {
         'age': 35,
         'occupation': 'Software Engineer',
         'skills': {
-            'languages': ['Japanese', 'English'],
+            'languages': [
+                'Japanese',
+                'English'],
             'expertise': [
                 'Server-Side Programming',
                 'Front-end Programming',
@@ -49,8 +62,14 @@ _USER_DATA = {
 
 
 @pytest.fixture(autouse=True)
-def _cleanup_pycaches():
-    before = set(glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True))
+def __cleanup_caches__() -> Iterator[None]:
+    before = set(
+        glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True))
     yield
     for pycache in before:
         if os.path.exists(pycache):
@@ -58,7 +77,7 @@ def _cleanup_pycaches():
 
 
 @pytest.fixture
-def users_workspace():
+def users_workspace() -> Iterator[tuple[str, str, str]]:
     dirname = os.path.join('.', 'test', 'tmp')
     filename = 'users.json'
     filepath = os.path.join(dirname, filename)

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import glob
+import re
 import json
 import os
 import shutil
@@ -63,17 +63,13 @@ _USER_DATA = {
 
 @pytest.fixture(autouse=True)
 def __cleanup_caches__() -> Iterator[None]:
-    before = set(
-        glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True))
     yield
-    for pycache in before:
-        if os.path.exists(pycache):
-            shutil.rmtree(pycache)
+    cache_dir = re.compile(r'^(?:__pycache__|\.pytest_cache|\.mypy_cache)$')
+    for root, dirs, _ in os.walk('.'):
+        for name in list(dirs):
+            if cache_dir.match(name):
+                shutil.rmtree(os.path.join(root, name), ignore_errors=True)
+                dirs.remove(name)
 
 
 @pytest.fixture

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -1,11 +1,12 @@
 import json
+from typing import Any
 
 import pytest
 
 from application import Application, InvalidFilenameError, InvalidOrderError
 
 
-def _read_json(filepath):
+def _read_json(filepath: str) -> Any:
     with open(filepath) as f:
         return json.load(f)
 
@@ -16,7 +17,9 @@ _SORTED_BY_ASC = {
         'name': 'Wade Williams',
         'occupation': 'Software Engineer',
         'skills': {
-            'languages': ['Japanese', 'English'],
+            'languages': [
+                'Japanese',
+                'English'],
             'expertise': [
                 'Server-Side Programming',
                 'Front-end Programming',
@@ -31,8 +34,18 @@ _SORTED_BY_ASC = {
         'name': 'Wade Williams',
         'occupation': 'Global Trading Marketer',
         'skills': {
-            'languages': ['Japanese', 'English', 'Spanish', 'German', 'French'],
-            'expertise': ['Marketing', 'Accounting', 'Interpretation', 'Translation', 'Economics'],
+            'languages': [
+                'Japanese',
+                'English',
+                'Spanish',
+                'German',
+                'French'],
+            'expertise': [
+                'Marketing',
+                'Accounting',
+                'Interpretation',
+                'Translation',
+                'Economics'],
         },
     },
     'user3': {
@@ -41,7 +54,9 @@ _SORTED_BY_ASC = {
         'name': 'Daisy Harris',
         'occupation': 'High School Teacher',
         'skills': {
-            'languages': ['English', 'Spanish'],
+            'languages': [
+                'English',
+                'Spanish'],
             'expertise': ['Teaching Foreign Language'],
         },
     },
@@ -50,18 +65,30 @@ _SORTED_BY_ASC = {
 _SORTED_BY_DESC = {
     'user3': {
         'skills': {
-            'languages': ['English', 'Spanish'],
+            'languages': [
+                'English',
+                'Spanish'],
             'expertise': ['Teaching Foreign Language'],
         },
         'occupation': 'High School Teacher',
         'name': 'Daisy Harris',
-        'gender': 'Female',
-        'age': 30,
+                'gender': 'Female',
+                'age': 30,
     },
     'user2': {
         'skills': {
-            'languages': ['Japanese', 'English', 'Spanish', 'German', 'French'],
-            'expertise': ['Marketing', 'Accounting', 'Interpretation', 'Translation', 'Economics'],
+            'languages': [
+                'Japanese',
+                'English',
+                'Spanish',
+                'German',
+                'French'],
+            'expertise': [
+                'Marketing',
+                'Accounting',
+                'Interpretation',
+                'Translation',
+                'Economics'],
         },
         'occupation': 'Global Trading Marketer',
         'name': 'Wade Williams',
@@ -70,7 +97,9 @@ _SORTED_BY_DESC = {
     },
     'user1': {
         'skills': {
-            'languages': ['Japanese', 'English'],
+            'languages': [
+                'Japanese',
+                'English'],
             'expertise': [
                 'Server-Side Programming',
                 'Front-end Programming',
@@ -85,31 +114,35 @@ _SORTED_BY_DESC = {
 }
 
 
-def test_sort_json_data_by_asc(users_workspace):
+def test_sort_json_data_by_asc(users_workspace: tuple[str, str, str]) -> None:
     dirname, filename, filepath = users_workspace
     Application(dirname=dirname, filename=filename).run()
     assert _read_json(filepath) == _SORTED_BY_ASC
 
 
-def test_sort_json_data_by_desc(users_workspace):
+def test_sort_json_data_by_desc(users_workspace: tuple[str, str, str]) -> None:
     dirname, filename, filepath = users_workspace
     Application(dirname=dirname, filename=filename, order='desc').run()
     assert _read_json(filepath) == _SORTED_BY_DESC
 
 
-def test_sort_json_data_with_missing_filename(users_workspace):
+def test_sort_json_data_with_missing_filename(
+        users_workspace: tuple[str, str, str]) -> None:
     dirname, _, _ = users_workspace
     with pytest.raises(InvalidFilenameError, match=r'^Filename must be provided\.$'):
         Application(dirname=dirname, filename='').run()
 
 
-def test_sort_json_data_with_invalid_order(users_workspace):
+def test_sort_json_data_with_invalid_order(
+        users_workspace: tuple[str, str, str]) -> None:
     dirname, filename, _ = users_workspace
     with pytest.raises(InvalidOrderError, match=r'^Order option must be either asc or desc\.$'):
         Application(dirname=dirname, filename=filename, order='hoge').run()
 
 
-def test_sort_json_data_with_non_string_order(users_workspace):
+def test_sort_json_data_with_non_string_order(
+        users_workspace: tuple[str, str, str]) -> None:
     dirname, filename, _ = users_workspace
     with pytest.raises(InvalidOrderError, match=r'^Unexpected param was provided$'):
-        Application(dirname=dirname, filename=filename, order=1).run()
+        Application(dirname=dirname, filename=filename,
+                    order=1).run()  # type: ignore[arg-type]


### PR DESCRIPTION
## 1. Why (Purpose)

Most personal Python projects had no static type checking, and code-style consistency was only partially enforced. The goals were to:

- **Introduce `mypy`** to every Python project so type regressions are caught in CI rather than at runtime.
- **Add reasonable type annotations** to the implementations (and add missing ones where mypy was partially present).
- **Enable the `mypy` job in GitHub Actions** so type checking runs on every push/PR (it was commented out in most workflows).
- **Enforce code convention** by running `autoflake8` + `autopep8` and fixing residual `flake8` violations, keeping the codebase clean and consistent.

## 2. What (Procedures)

Processed **13 Python repositories** (the `github-wiki-organisers-wiki` repo was skipped — the project is a git submodule there). Per project:

1. Ensured `mypy==2.0.0` in `requirements.txt` (added to `deep-learnings`, `natural-language-processing`).
2. Added a `[tool.mypy]` block in `pyproject.toml` (created where missing).
3. Added type annotations across `src/`, `test/`, `conftest.py`, `main.py`, `exec/` so `mypy` passes; fixed genuine type bugs found along the way (`*_` argv-unpack reuse, a literally-duplicated class in `embedding_dot.py`, a duplicated optional-import block, a missing `import urllib.parse`, `from X import *` → explicit imports).
4. Enabled the previously-commented `mypy` CI job; added `run_mypy.sh` for multi-subproject/volume repos to avoid duplicate-module collisions.
5. Ran `autoflake8 --in-place --remove-duplicate-keys --remove-unused-variables --recursive .` and `autopep8 --in-place --aggressive --aggressive --recursive .`, then fixed remaining `flake8` violations (E501, E402, E114/E131, F811, F403/F405).
6. Verified each unit with `mypy`, `flake8` (project CI settings), and `pytest`.

**Strictness policy:** application projects use strict config (`disallow_untyped_defs = true`, matching the existing `file-cleaners` convention); the numpy/learning repos (`tutorials`, `natural-language-processing`, `deep-learnings`) use a lenient config — mirroring the user's own pre-existing lenient `deep-learnings` setup.

**Commits:** two semantic units per repo on the existing topic branch, local only — *“Introduce mypy type checking”* (config/deps/CI/`run_mypy.sh`) and *“Apply autoflake8/autopep8 and fix flake8 violations”* (source pass). Repos already mypy-enabled got only the second commit.

A separate follow-up fix: `save_dicision_boundary_image` (deep-learnings vol2) didn’t open a fresh matplotlib figure, so it rendered onto the leftover loss-plot figure when the test suite ran in one process — corrupting `img/dicision_boundary.png`. Added `plt.figure()` and restored the curated original PNGs (commit `00ed73c`).

## 3. How (Operation and Maintenance)

- **Toolchain:** Windows had no usable Python; the toolchain (Python 3.14, mypy 2.0, flake8, autopep8, autoflake8, pytest) runs under **WSL Ubuntu**. Run all checks there against `/mnt/c/...`.
- **Run type checks:** single-unit projects — `mypy .` from the project dir. `coding-tests` — `bash run_mypy.sh` from `python/` (iterates the 5 subprojects). `deep-learnings` — `bash run_mypy.sh vol1|vol2` from repo root (root `pyproject.toml` config applies); `vol3` is checked per-chapter (intentionally reused module basenames, same reason pytest uses `--import-mode=importlib`).
- **Lint maintenance:** re-run the mandated `autoflake8`/`autopep8` pair, then `flake8 . --max-complexity=10 --max-line-length=127`.
- **CI:** `mypy` jobs are now active in the workflows; pushing the topic branches will exercise them on GitHub.
- **Caveat for maintainers:** several deep-learnings tests `savefig` directly into the tracked `img/` directory, so a full test run rewrites those committed PNGs (now correctly, after the figure fix). Consider redirecting test image output to a temp/untracked path.

## 4. Pros & Cons

### Pros

- Static type safety now enforced in CI across all projects; many latent bugs surfaced and fixed.
- Consistent, convention-compliant formatting; clean `flake8`/`mypy`/`pytest` across the board.
- Per-repo, semantically split commits make review and selective reverts easy.
- Pragmatic per-domain strictness keeps numpy/learning code maintainable without low-value churn.

### Cons & Trade-offs

- A few targeted `# type: ignore` for genuine pre-existing oddities (e.g. `list - dict_keys` valid only via `Set.__rsub__`); not full type purity.
- Type annotations and `autopep8` reflow are interleaved in the same files, so the two semantic commits split at the infra-vs-source boundary rather than purely "types vs lint".
- `autopep8 --aggressive --aggressive` produced some visually awkward wrapping (e.g. multi-line f-strings) — functional but not hand-tuned.
- `deep-learnings/vol2/train/` & `vol2/evaluate/` are pre-existing broken, non-tested experiment scripts — excluded from mypy rather than rewritten.

## 5. Others

- **Skipped:** `github-wiki-organisers-wiki` (the project is a git submodule of the `.wiki` repo — editing it would be wrong).
- **Nothing pushed** — all commits are local on the `hayat01sh1da/python/install-type-checking` topic branch in each repo, per request.
- **Pre-existing, out-of-scope issue flagged:** `natural-language-processing/.github/workflows/1_prereqiosotes.yml` has inconsistent path filters/filename (`vol1/**` vs `1_prerequisites`); left unchanged.
- **Environment-dependent tests:** `web-scrapers` (chromedriver) and `calculator_cli_app` (`CALCULATION_API`) passed in the WSL env but depend on external setup in CI.
- **Verification results:** all units green — e.g. github-wiki-organisers (mypy 14, pytest 32), web-scrapers (mypy 17, pytest 8), coding-tests (pytest 200/2/80/3/4), deep-learnings (mypy 42/108/all-chapters, pytest 48/153/15).