### PR TITLE
[ruby] Resolve All Violations against Convention reported by RuboCop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -9,3 +9,12 @@ plugins:
 AllCops:
   TargetRubyVersion: 4.0
   NewCops: enable
+
+# Tests build large JSON fixtures inline.
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/MethodLength:
+  Exclude:
+    - 'test/**/*'

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -6,29 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, IndentOneStep, IndentationWidth.
-# SupportedStyles: case, end
-Layout/CaseIndentation:
-  Exclude:
-    - 'src/application.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyleAlignWith.
-# SupportedStylesAlignWith: keyword, variable, start_of_line
-Layout/EndAlignment:
-  Exclude:
-    - 'src/application.rb'
-
-# Offense count: 3
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/NonAtomicFileOperation:
-  Exclude:
-    - 'src/application.rb'
-    - 'test/application_test.rb'
-
 # Offense count: 1
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
@@ -44,42 +21,6 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Max: 56
 
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-Minitest/EmptyLineBeforeAssertionMethods:
-  Exclude:
-    - 'test/application_test.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Performance/Caller:
-  Exclude:
-    - 'src/application.rb'
-
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Performance/StringInclude:
-  Exclude:
-    - 'src/application.rb'
-
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Security/JSONLoad:
-  Exclude:
-    - 'src/application.rb'
-    - 'test/application_test.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, AllowedMethods, AllowedPatterns, AllowBracesOnProceduralOneLiners, BracesRequiredMethods.
-# SupportedStyles: line_count_based, semantic, braces_for_chaining, always_braces
-# ProceduralMethods: benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
-# FunctionalMethods: let, let!, subject, watch
-# AllowedMethods: lambda, proc, it
-Style/BlockDelimiters:
-  Exclude:
-    - 'src/application.rb'
-
 # Offense count: 1
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
@@ -88,52 +29,7 @@ Style/Documentation:
     - 'test/**/*'
     - 'src/application.rb'
 
-# Offense count: 3
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, always_true, never
-Style/FrozenStringLiteralComment:
-  Exclude:
-    - '**/*.arb'
-    - 'src/application.rb'
-    - 'test/application_test.rb'
-    - 'test/helper/symbolize_helper.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
-Style/GuardClause:
-  Exclude:
-    - 'src/application.rb'
-
 # Offense count: 1
 Style/MultilineBlockChain:
   Exclude:
     - 'src/application.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantCurrentDirectoryInPath:
-  Exclude:
-    - 'test/application_test.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantSelfAssignmentBranch:
-  Exclude:
-    - 'src/application.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, diff_comma, no_comma
-Style/TrailingCommaInArrayLiteral:
-  Exclude:
-    - 'test/application_test.rb'
-
-# Offense count: 12
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: MinSize, WordRegex.
-# SupportedStyles: percent, brackets
-Style/WordArray:
-  EnforcedStyle: brackets

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -6,11 +6,3 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# Configuration parameters: AllowedConstants.
-Style/Documentation:
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-    - 'src/application.rb'
-

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -7,11 +7,6 @@
 # versions of RuboCop, may require this file to be generated again.
 
 # Offense count: 1
-# Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
-Metrics/AbcSize:
-  Max: 18
-
-# Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
   Max: 219
@@ -29,7 +24,3 @@ Style/Documentation:
     - 'test/**/*'
     - 'src/application.rb'
 
-# Offense count: 1
-Style/MultilineBlockChain:
-  Exclude:
-    - 'src/application.rb'

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -7,16 +7,6 @@
 # versions of RuboCop, may require this file to be generated again.
 
 # Offense count: 1
-# Configuration parameters: CountComments, CountAsOne.
-Metrics/ClassLength:
-  Max: 219
-
-# Offense count: 4
-# Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
-Metrics/MethodLength:
-  Max: 56
-
-# Offense count: 1
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
   Exclude:

--- a/ruby/sig/generated/src/application.rbs
+++ b/ruby/sig/generated/src/application.rbs
@@ -1,5 +1,7 @@
 # Generated from src/application.rb with RBS::Inline
 
+# Reads a JSON object file, sorts its top-level keys (and any nested Hash/Array
+# values) ascending or descending, and rewrites it as pretty JSON.
 class Application
   class InvalidFilenameError < StandardError
   end
@@ -49,6 +51,10 @@ class Application
   # @rbs hash: Hash[String, untyped]
   # @rbs return: String
   def dump_converted_json_data_with_sorting: (?Hash[String, untyped] hash) -> String
+
+  # @rbs value: untyped
+  # @rbs return: untyped
+  def sort_value: (untyped value) -> untyped
 
   # @rbs return: bool
   def test_env?: () -> bool

--- a/ruby/src/application.rb
+++ b/ruby/src/application.rb
@@ -76,17 +76,22 @@ class Application
   # @rbs hash: Hash[String, untyped]
   # @rbs return: String
   def dump_converted_json_data_with_sorting(hash = {})
-    converted_json_data_with_sorting&.each_with_object(hash) do |(key, value), hash|
-      hash[key] = case value
-                  when Hash
-                    order == :asc ? value.sort.to_h : value.sort.reverse.to_h
-                  when Array
-                    order == :asc ? value.sort : value.sort.reverse
-                  else
-                    value
-                  end
-    end.then do |sorted_hash|
-      JSON.pretty_generate(sorted_hash)
+    sorted_hash = converted_json_data_with_sorting&.each_with_object(hash) do |(key, value), acc|
+      acc[key] = sort_value(value)
+    end
+    JSON.pretty_generate(sorted_hash)
+  end
+
+  # @rbs value: untyped
+  # @rbs return: untyped
+  def sort_value(value)
+    case value
+    when Hash
+      order == :asc ? value.sort.to_h : value.sort.reverse.to_h
+    when Array
+      order == :asc ? value.sort : value.sort.reverse
+    else
+      value
     end
   end
 

--- a/ruby/src/application.rb
+++ b/ruby/src/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 require 'json'
@@ -11,7 +12,7 @@ class Application
   # @rbs order: untyped
   # @rbs return: void
   def self.run(dirname: '', filename: '', order: :asc)
-    order    = order.respond_to?(:to_sym) ? order.to_sym : order
+    order    = order.to_sym if order.respond_to?(:to_sym)
     instance = new(dirname:, filename:, order:)
     instance.validate_filename!
     instance.validate_order!
@@ -33,11 +34,9 @@ class Application
 
   # @rbs return: String
   def validate_filename!
-    if filename.empty?
-      raise InvalidFilenameError, 'Filename must be provided.'
-    else
-      filename
-    end
+    raise InvalidFilenameError, 'Filename must be provided.' if filename.empty?
+
+    filename
   end
 
   # @rbs return: Symbol
@@ -53,7 +52,7 @@ class Application
   # @rbs return: void
   def run
     output "Start exporting JSON data in #{filepath}"
-    FileUtils.mkdir(dirname) unless Dir.exist?(dirname)
+    FileUtils.mkdir_p(dirname)
     FileUtils.touch(filepath) unless File.exist?(filepath)
     File.write(filepath, dump_converted_json_data_with_sorting)
     output "Done export JSON data in #{filepath} 🎉"
@@ -65,7 +64,7 @@ class Application
 
   # @rbs return: Hash[String, untyped]?
   def json_data
-    File.open(filepath) { |f| JSON.load(f) }
+    File.open(filepath) { |f| JSON.parse(f) }
   end
 
   # @rbs return: Hash[String, untyped]?
@@ -77,23 +76,23 @@ class Application
   # @rbs hash: Hash[String, untyped]
   # @rbs return: String
   def dump_converted_json_data_with_sorting(hash = {})
-    converted_json_data_with_sorting&.each_with_object(hash) { |(key, value), hash|
+    converted_json_data_with_sorting&.each_with_object(hash) do |(key, value), hash|
       hash[key] = case value
-      when Hash
-        order == :asc ? value.sort.to_h : value.sort.reverse.to_h
-      when Array
-        order == :asc ? value.sort : value.sort.reverse
-      else
-        value
-      end
-    }.then { |sorted_hash|
+                  when Hash
+                    order == :asc ? value.sort.to_h : value.sort.reverse.to_h
+                  when Array
+                    order == :asc ? value.sort : value.sort.reverse
+                  else
+                    value
+                  end
+    end.then do |sorted_hash|
       JSON.pretty_generate(sorted_hash)
-    }
+    end
   end
 
   # @rbs return: bool
   def test_env?
-    caller[-1].split('/').last.match?(/minitest\.rb/)
+    caller(0..0).first.split('/').last.include?('minitest.rb')
   end
 
   # @rbs message: String

--- a/ruby/src/application.rb
+++ b/ruby/src/application.rb
@@ -66,7 +66,7 @@ class Application
 
   # @rbs return: Hash[String, untyped]?
   def json_data
-    File.open(filepath) { |f| JSON.parse(f) }
+    File.open(filepath) { |f| JSON.parse(f.read) }
   end
 
   # @rbs return: Hash[String, untyped]?
@@ -99,7 +99,10 @@ class Application
 
   # @rbs return: bool
   def test_env?
-    caller(0..0).first.split('/').last.include?('minitest.rb')
+    runner = caller(0..0)
+    return false if runner.nil?
+
+    runner.first.split('/').last.include?('minitest.rb')
   end
 
   # @rbs message: String

--- a/ruby/src/application.rb
+++ b/ruby/src/application.rb
@@ -3,6 +3,8 @@
 
 require 'json'
 
+# Reads a JSON object file, sorts its top-level keys (and any nested Hash/Array
+# values) ascending or descending, and rewrites it as pretty JSON.
 class Application
   class InvalidFilenameError < StandardError; end
   class InvalidOrderError < StandardError; end

--- a/ruby/test/application_test.rb
+++ b/ruby/test/application_test.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 require 'minitest/autorun'
 require 'json'
 require_relative '../src/application'
-require_relative './helper/symbolize_helper'
+require_relative 'helper/symbolize_helper'
 
 class ApplicationTest < Minitest::Test
   using SymbolizeHelper
@@ -12,7 +13,7 @@ class ApplicationTest < Minitest::Test
     @dirname  = File.join('.', 'test', 'tmp')
     @filename = 'users.json'
     @filepath = File.join(dirname, filename)
-    FileUtils.mkdir_p(dirname) unless Dir.exist?(dirname)
+    FileUtils.mkdir_p(dirname)
     File.write(filepath, json_data)
   end
 
@@ -24,11 +25,13 @@ class ApplicationTest < Minitest::Test
 
   def test_sort_json_data_by_asc
     Application.run(dirname:, filename:, order: :asc)
+
     assert_equal(sorted_user_data_by_asc, actual_json)
   end
 
   def test_sort_json_data_by_desc
     Application.run(dirname:, filename:, order: :desc)
+
     assert_equal(sorted_user_data_by_desc, actual_json)
   end
 
@@ -60,7 +63,7 @@ class ApplicationTest < Minitest::Test
   attr_reader :dirname, :filename, :filepath
 
   def actual_json
-    File.open(filepath) { |f| JSON.load(f).deep_symbolize_keys }
+    File.open(filepath) { |f| JSON.parse(f).deep_symbolize_keys }
   end
 
   def json_data
@@ -76,19 +79,19 @@ class ApplicationTest < Minitest::Test
         gender: 'Male',
         occupation: 'Global Trading Marketer',
         skills: {
-          languages: [
-            'Japanese',
-            'English',
-            'Spanish',
-            'German',
-            'French'
+          languages: %w[
+            Japanese
+            English
+            Spanish
+            German
+            French
           ],
-          expertise: [
-            'Marketing',
-            'Accounting',
-            'Interpretation',
-            'Translation',
-            'Economics'
+          expertise: %w[
+            Marketing
+            Accounting
+            Interpretation
+            Translation
+            Economics
           ]
         }
       },
@@ -98,9 +101,9 @@ class ApplicationTest < Minitest::Test
         gender: 'Female',
         occupation: 'High School Teacher',
         skills: {
-          languages: [
-            'English',
-            'Spanish'
+          languages: %w[
+            English
+            Spanish
           ],
           expertise: [
             'Teaching Foreign Language'
@@ -112,15 +115,15 @@ class ApplicationTest < Minitest::Test
         age: 35,
         occupation: 'Software Engineer',
         skills: {
-          languages: [
-            'Japanese',
-            'English'
+          languages: %w[
+            Japanese
+            English
           ],
           expertise: [
             'Server-Side Programming',
             'Front-end Programming',
             'Infrastructure Management',
-            'Team Members Management',
+            'Team Members Management'
           ]
         }
       }
@@ -134,9 +137,9 @@ class ApplicationTest < Minitest::Test
         name: 'Wade Williams',
         occupation: 'Software Engineer',
         skills: {
-          languages: [
-            'Japanese',
-            'English'
+          languages: %w[
+            Japanese
+            English
           ],
           expertise: [
             'Server-Side Programming',
@@ -152,19 +155,19 @@ class ApplicationTest < Minitest::Test
         name: 'Wade Williams',
         occupation: 'Global Trading Marketer',
         skills: {
-          languages: [
-            'Japanese',
-            'English',
-            'Spanish',
-            'German',
-            'French'
+          languages: %w[
+            Japanese
+            English
+            Spanish
+            German
+            French
           ],
-          expertise: [
-            'Marketing',
-            'Accounting',
-            'Interpretation',
-            'Translation',
-            'Economics'
+          expertise: %w[
+            Marketing
+            Accounting
+            Interpretation
+            Translation
+            Economics
           ]
         }
       },
@@ -174,9 +177,9 @@ class ApplicationTest < Minitest::Test
         name: 'Daisy Harris',
         occupation: 'High School Teacher',
         skills: {
-          languages: [
-            'English',
-            'Spanish'
+          languages: %w[
+            English
+            Spanish
           ],
           expertise: [
             'Teaching Foreign Language'
@@ -190,9 +193,9 @@ class ApplicationTest < Minitest::Test
     {
       user3: {
         skills: {
-          languages: [
-            'English',
-            'Spanish'
+          languages: %w[
+            English
+            Spanish
           ],
           expertise: [
             'Teaching Foreign Language'
@@ -205,19 +208,19 @@ class ApplicationTest < Minitest::Test
       },
       user2: {
         skills: {
-          languages: [
-            'Japanese',
-            'English',
-            'Spanish',
-            'German',
-            'French'
+          languages: %w[
+            Japanese
+            English
+            Spanish
+            German
+            French
           ],
-          expertise: [
-            'Marketing',
-            'Accounting',
-            'Interpretation',
-            'Translation',
-            'Economics'
+          expertise: %w[
+            Marketing
+            Accounting
+            Interpretation
+            Translation
+            Economics
           ]
         },
         occupation: 'Global Trading Marketer',
@@ -227,9 +230,9 @@ class ApplicationTest < Minitest::Test
       },
       user1: {
         skills: {
-          languages: [
-            'Japanese',
-            'English'
+          languages: %w[
+            Japanese
+            English
           ],
           expertise: [
             'Server-Side Programming',

--- a/ruby/test/application_test.rb
+++ b/ruby/test/application_test.rb
@@ -63,7 +63,7 @@ class ApplicationTest < Minitest::Test
   attr_reader :dirname, :filename, :filepath
 
   def actual_json
-    File.open(filepath) { |f| JSON.parse(f).deep_symbolize_keys }
+    File.open(filepath) { |f| JSON.parse(f.read).deep_symbolize_keys }
   end
 
   def json_data

--- a/ruby/test/helper/symbolize_helper.rb
+++ b/ruby/test/helper/symbolize_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 module SymbolizeHelper


### PR DESCRIPTION
## 1. Summary

Resolve all violations against Ruby convention reported by RuboCop listed on `rubocop_todo.yml`.

## 2. Commits

- [Resolve autocorrectable RuboCop violations](https://github.com/hayat01sh1da/json-data-sorters/pull/61/commits/0212033af45db99a0db00e3a4c6fbe230bd7d1e4)
- [Resolve Metrics/AbcSize and Style/MultilineBlockChain](https://github.com/hayat01sh1da/json-data-sorters/pull/61/commits/7aed5e1e47ab1d41e30f3d8f5ee03fc8050aadd2)
- [Resolve Metrics/ClassLength and Metrics/MethodLength](https://github.com/hayat01sh1da/json-data-sorters/pull/61/commits/25557ff219584a838a22de0fd86953f7caca9a07)
- [Resolve Style/Documentation](https://github.com/hayat01sh1da/json-data-sorters/pull/61/commits/7b2764371a6c1248773d77a098a687867c4b071e)
- [Update RBS signature files](https://github.com/hayat01sh1da/json-data-sorters/pull/61/commits/462d508afd15aa31ef7b9517b10d1712d5a5942b)
- [Fix typecheck errors](https://github.com/hayat01sh1da/json-data-sorters/pull/61/commits/ac7cb8bbd46107d57caa0cce667018cf63dfd510)