### PR TITLE
[ruby] Update Gem Dependencies

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
     fileutils (1.8.0)
-    json (2.19.8)
+    json (2.19.9)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -128,7 +128,7 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
-  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2


### PR DESCRIPTION
## 1. Overview

`json` gem 2.19.9 (released 2026-06-11) is a single-fix security patch over 2.19.8.  
It fixes a buffer overflow that could crash the process when generating JSON directly into an IO object via `JSON.generate(object, io)`.  
The issue has a CVE pending.  
There are no API or behavioural changes — upgrading is safe and strongly recommended.

## 2. Key Changes

**Bug fixes (security):**

- Fixed a **buffer overflow that could lead to a crash** when writing JSON directly into an IO with `JSON.generate(object, io)`. *(CVE pending.)*

## 3. Summary

A focused security patch with one change: it closes a memory-safety bug in the IO-streaming path of `JSON.generate`.  
Applications that pass an IO object as the second argument to `JSON.generate` were exposed to a potential crash and should upgrade.  
No other behaviour changes — a drop-in patch upgrade from 2.19.8.

## 4. References

- [json/CHANGELOG.md > 2026-06-11 (2.19.9)](https://github.com/ruby/json/blob/master/CHANGES.md#2026-06-11-2199)
- [Comparing changes between v2.19.8 and v2.19.9](https://github.com/ruby/json/compare/v2.19.8...v2.19.9)