### PR TITLE
[ruby] Update Gem Dependencies

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     csv (3.3.5)
     ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
@@ -114,7 +114,7 @@ DEPENDENCIES
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df


### PR DESCRIPTION
## 1. concurrent-ruby: 1.3.6 → 1.3.7

Release date: **16 June 2026** · [Release notes](https://github.com/ruby-concurrency/concurrent-ruby/releases/tag/v1.3.7) · [Compare v1.3.6...v1.3.7](https://github.com/ruby-concurrency/concurrent-ruby/compare/v1.3.6...v1.3.7) (14 commits)

This is primarily a **security / thread-safety bug-fix release** (three Low-severity CVEs).

### 1-1. Security fixes

- **[CVE-2026-54904](https://www.cve.org/CVERecord?id=CVE-2026-54904) — `AtomicReference#update`:** Fixed an infinite retry loop / livelock that occurred when the stored value is `Float::NAN`.
- **[CVE-2026-5490](https://www.cve.org/CVERecord?CVE-2026-5490) — `ReentrantReadWriteLock`:** Fixed a read hold-count overflow that spilled into the write-lock bit after 32,768 reentrant reads.
- **[CVE-2026-54906](https://nvd.nist.gov/vuln/detail/CVE-2026-45490) — `ReadWriteLock`:** Fixed two issues:
  - Any thread could release a write lock held by another thread, breaking write exclusivity.
  - An unconditional decrement on read release dropped the counter to `-1`, blocking all subsequent lock acquisitions.

### 1-2. Infrastructure / other

- Built `concurrent-ruby-ext` correctly on **Darwin 32-bit** systems (#1064).
- Added **SECURITY.md** documentation (#1104).
- Added **Ruby 4.0** to the CI test matrix (#1106).
- Bumped GitHub Actions (`deploy-pages` v4→v5, `upload-pages-artifact` v4→v5).
- Adjusted test timing to reduce transient failures in `ReentrantReadWriteLock` specs.

**Contributors:** @eregon, @joshuay03, @barracuda156 (first contribution).

> Maintainers recommend updating for the security patches, though real-world impact is considered unlikely.

## 2. Bottom line

- **concurrent-ruby 1.3.7** is a security patch (three Low-severity CVEs in `AtomicReference` / `ReadWriteLock` / `ReentrantReadWriteLock`) plus CI/platform housekeeping — safe, recommended bump.
- **i18n 1.15.1** adds Fiber-aware storage and thread-safe lazy loading (with a v1.15.1 fix on top), improves transliteration, and **raises the minimum Ruby to 3.2** — verify the project runs on Ruby 3.2+ before merging.