### PR TITLE
[python] Update pip Library Dependencies

### DIFF
--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -1,4 +1,4 @@
-ast_serialize==0.5.0
+ast_serialize==0.6.0
 autoflake8==0.4.1
 autopep8==2.3.2
 flake8==7.3.0


### PR DESCRIPTION
## 1. Overview

This branch performs routine maintenance of the project's pinned Python (pip) library versions.
It updates a single dependency in `python/requirements.lock` to its latest release, keeping the toolchain current.
No application or test code is touched.

## 2. Key Changes & Differences

| Libraries       | Before | After | Changes & Differences                                                |
| :-------------- | :----- | :---- | :------------------------------------------------------------------- |
| `ast_serialize` | 0.5.0  | 0.6.0 | Minor version bump of the AST serialization library in the lockfile. |

## 3. Summary

`ast_serialize` is bumped from **0.5.0** to **0.6.0** in `python/requirements.lock`. This is a low-risk, dependency-only change with no functional impact on the codebase.

## 4. References

- [ast_serialize on PyPI](https://pypi.org/project/ast-serialize/)
- [pip lockfile](./python/requirements.lock)