### PR TITLE
[ruby] Optimise Architecture of App

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -7,3 +7,7 @@ plugins:
 AllCops:
   TargetRubyVersion: 4.0
   NewCops: enable
+
+# `#:` is the rbs-inline trailing type annotation, not a malformed comment.
+Layout/LeadingCommentSpace:
+  AllowRBSInlineAnnotation: true

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -7,7 +7,3 @@ plugins:
 AllCops:
   TargetRubyVersion: 4.0
   NewCops: enable
-
-# `#:` is the rbs-inline trailing type annotation, not a malformed comment.
-Layout/LeadingCommentSpace:
-  AllowRBSInlineAnnotation: true

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -7,12 +7,3 @@ plugins:
 AllCops:
   TargetRubyVersion: 4.0
   NewCops: enable
-
-# Tests build large JSON fixtures inline.
-Metrics/ClassLength:
-  Exclude:
-    - 'test/**/*'
-
-Metrics/MethodLength:
-  Exclude:
-    - 'test/**/*'

--- a/ruby/sig/generated/test/application_test.rbs
+++ b/ruby/sig/generated/test/application_test.rbs
@@ -1,6 +1,10 @@
 # Generated from test/application_test.rb with RBS::Inline
 
+# Tests the JSON data sorter against fixture data under test/fixtures/.
+# Conf. https://7esl.com/english-names/ for the fixture names.
 class ApplicationTest < Minitest::Test
+  FIXTURES_DIR: String
+
   def setup: () -> untyped
 
   def teardown: () -> untyped
@@ -25,10 +29,9 @@ class ApplicationTest < Minitest::Test
 
   def actual_json: () -> untyped
 
-  def json_data: () -> untyped
-
-  # Conf. https://7esl.com/english-names/
-  def user_data: () -> untyped
+  # @rbs basename: String
+  # @rbs return: Hash[Symbol, untyped]
+  def fixture_json: (String basename) -> Hash[Symbol, untyped]
 
   def sorted_user_data_by_asc: () -> untyped
 

--- a/ruby/test/application_test.rb
+++ b/ruby/test/application_test.rb
@@ -11,7 +11,7 @@ require_relative 'helper/symbolize_helper'
 class ApplicationTest < Minitest::Test
   using SymbolizeHelper
 
-  FIXTURES_DIR = File.join('.', 'test', 'fixtures')
+  FIXTURES_DIR = File.join('.', 'test', 'fixtures') #: String
 
   def setup
     @dirname  = File.join('.', 'test', 'tmp')
@@ -70,6 +70,8 @@ class ApplicationTest < Minitest::Test
     File.open(filepath) { |f| JSON.parse(f.read).deep_symbolize_keys }
   end
 
+  # @rbs basename: String
+  # @rbs return: Hash[Symbol, untyped]
   def fixture_json(basename)
     File.open(File.join(FIXTURES_DIR, basename)) { |f| JSON.parse(f.read).deep_symbolize_keys }
   end

--- a/ruby/test/application_test.rb
+++ b/ruby/test/application_test.rb
@@ -11,7 +11,11 @@ require_relative 'helper/symbolize_helper'
 class ApplicationTest < Minitest::Test
   using SymbolizeHelper
 
-  FIXTURES_DIR = File.join('.', 'test', 'fixtures') #: String
+  # @rbs skip
+  FIXTURES_DIR = File.join('.', 'test', 'fixtures')
+
+  # @rbs!
+  #   FIXTURES_DIR: String
 
   def setup
     @dirname  = File.join('.', 'test', 'tmp')

--- a/ruby/test/application_test.rb
+++ b/ruby/test/application_test.rb
@@ -6,15 +6,19 @@ require 'json'
 require_relative '../src/application'
 require_relative 'helper/symbolize_helper'
 
+# Tests the JSON data sorter against fixture data under test/fixtures/.
+# Conf. https://7esl.com/english-names/ for the fixture names.
 class ApplicationTest < Minitest::Test
   using SymbolizeHelper
+
+  FIXTURES_DIR = File.join('.', 'test', 'fixtures')
 
   def setup
     @dirname  = File.join('.', 'test', 'tmp')
     @filename = 'users.json'
     @filepath = File.join(dirname, filename)
     FileUtils.mkdir_p(dirname)
-    File.write(filepath, json_data)
+    FileUtils.cp(File.join(FIXTURES_DIR, 'users.json'), filepath)
   end
 
   def teardown
@@ -66,185 +70,15 @@ class ApplicationTest < Minitest::Test
     File.open(filepath) { |f| JSON.parse(f.read).deep_symbolize_keys }
   end
 
-  def json_data
-    JSON.dump(user_data)
-  end
-
-  # Conf. https://7esl.com/english-names/
-  def user_data
-    {
-      user2: {
-        name: 'Wade Williams',
-        age: 45,
-        gender: 'Male',
-        occupation: 'Global Trading Marketer',
-        skills: {
-          languages: %w[
-            Japanese
-            English
-            Spanish
-            German
-            French
-          ],
-          expertise: %w[
-            Marketing
-            Accounting
-            Interpretation
-            Translation
-            Economics
-          ]
-        }
-      },
-      user3: {
-        name: 'Daisy Harris',
-        age: 30,
-        gender: 'Female',
-        occupation: 'High School Teacher',
-        skills: {
-          languages: %w[
-            English
-            Spanish
-          ],
-          expertise: [
-            'Teaching Foreign Language'
-          ]
-        }
-      },
-      user1: {
-        name: 'Wade Williams',
-        age: 35,
-        occupation: 'Software Engineer',
-        skills: {
-          languages: %w[
-            Japanese
-            English
-          ],
-          expertise: [
-            'Server-Side Programming',
-            'Front-end Programming',
-            'Infrastructure Management',
-            'Team Members Management'
-          ]
-        }
-      }
-    }
+  def fixture_json(basename)
+    File.open(File.join(FIXTURES_DIR, basename)) { |f| JSON.parse(f.read).deep_symbolize_keys }
   end
 
   def sorted_user_data_by_asc
-    {
-      user1: {
-        age: 35,
-        name: 'Wade Williams',
-        occupation: 'Software Engineer',
-        skills: {
-          languages: %w[
-            Japanese
-            English
-          ],
-          expertise: [
-            'Server-Side Programming',
-            'Front-end Programming',
-            'Infrastructure Management',
-            'Team Members Management'
-          ]
-        }
-      },
-      user2: {
-        age: 45,
-        gender: 'Male',
-        name: 'Wade Williams',
-        occupation: 'Global Trading Marketer',
-        skills: {
-          languages: %w[
-            Japanese
-            English
-            Spanish
-            German
-            French
-          ],
-          expertise: %w[
-            Marketing
-            Accounting
-            Interpretation
-            Translation
-            Economics
-          ]
-        }
-      },
-      user3: {
-        age: 30,
-        gender: 'Female',
-        name: 'Daisy Harris',
-        occupation: 'High School Teacher',
-        skills: {
-          languages: %w[
-            English
-            Spanish
-          ],
-          expertise: [
-            'Teaching Foreign Language'
-          ]
-        }
-      }
-    }
+    fixture_json('users_sorted_asc.json')
   end
 
   def sorted_user_data_by_desc
-    {
-      user3: {
-        skills: {
-          languages: %w[
-            English
-            Spanish
-          ],
-          expertise: [
-            'Teaching Foreign Language'
-          ]
-        },
-        occupation: 'High School Teacher',
-        name: 'Daisy Harris',
-        gender: 'Female',
-        age: 30
-      },
-      user2: {
-        skills: {
-          languages: %w[
-            Japanese
-            English
-            Spanish
-            German
-            French
-          ],
-          expertise: %w[
-            Marketing
-            Accounting
-            Interpretation
-            Translation
-            Economics
-          ]
-        },
-        occupation: 'Global Trading Marketer',
-        name: 'Wade Williams',
-        gender: 'Male',
-        age: 45
-      },
-      user1: {
-        skills: {
-          languages: %w[
-            Japanese
-            English
-          ],
-          expertise: [
-            'Server-Side Programming',
-            'Front-end Programming',
-            'Infrastructure Management',
-            'Team Members Management'
-          ]
-        },
-        occupation: 'Software Engineer',
-        name: 'Wade Williams',
-        age: 35
-      }
-    }
+    fixture_json('users_sorted_desc.json')
   end
 end

--- a/ruby/test/fixtures/users.json
+++ b/ruby/test/fixtures/users.json
@@ -1,0 +1,31 @@
+{
+  "user2": {
+    "name": "Wade Williams",
+    "age": 45,
+    "gender": "Male",
+    "occupation": "Global Trading Marketer",
+    "skills": {
+      "languages": ["Japanese", "English", "Spanish", "German", "French"],
+      "expertise": ["Marketing", "Accounting", "Interpretation", "Translation", "Economics"]
+    }
+  },
+  "user3": {
+    "name": "Daisy Harris",
+    "age": 30,
+    "gender": "Female",
+    "occupation": "High School Teacher",
+    "skills": {
+      "languages": ["English", "Spanish"],
+      "expertise": ["Teaching Foreign Language"]
+    }
+  },
+  "user1": {
+    "name": "Wade Williams",
+    "age": 35,
+    "occupation": "Software Engineer",
+    "skills": {
+      "languages": ["Japanese", "English"],
+      "expertise": ["Server-Side Programming", "Front-end Programming", "Infrastructure Management", "Team Members Management"]
+    }
+  }
+}

--- a/ruby/test/fixtures/users_sorted_asc.json
+++ b/ruby/test/fixtures/users_sorted_asc.json
@@ -1,0 +1,31 @@
+{
+  "user1": {
+    "age": 35,
+    "name": "Wade Williams",
+    "occupation": "Software Engineer",
+    "skills": {
+      "languages": ["Japanese", "English"],
+      "expertise": ["Server-Side Programming", "Front-end Programming", "Infrastructure Management", "Team Members Management"]
+    }
+  },
+  "user2": {
+    "age": 45,
+    "gender": "Male",
+    "name": "Wade Williams",
+    "occupation": "Global Trading Marketer",
+    "skills": {
+      "languages": ["Japanese", "English", "Spanish", "German", "French"],
+      "expertise": ["Marketing", "Accounting", "Interpretation", "Translation", "Economics"]
+    }
+  },
+  "user3": {
+    "age": 30,
+    "gender": "Female",
+    "name": "Daisy Harris",
+    "occupation": "High School Teacher",
+    "skills": {
+      "languages": ["English", "Spanish"],
+      "expertise": ["Teaching Foreign Language"]
+    }
+  }
+}

--- a/ruby/test/fixtures/users_sorted_desc.json
+++ b/ruby/test/fixtures/users_sorted_desc.json
@@ -1,0 +1,31 @@
+{
+  "user3": {
+    "skills": {
+      "languages": ["English", "Spanish"],
+      "expertise": ["Teaching Foreign Language"]
+    },
+    "occupation": "High School Teacher",
+    "name": "Daisy Harris",
+    "gender": "Female",
+    "age": 30
+  },
+  "user2": {
+    "skills": {
+      "languages": ["Japanese", "English", "Spanish", "German", "French"],
+      "expertise": ["Marketing", "Accounting", "Interpretation", "Translation", "Economics"]
+    },
+    "occupation": "Global Trading Marketer",
+    "name": "Wade Williams",
+    "gender": "Male",
+    "age": 45
+  },
+  "user1": {
+    "skills": {
+      "languages": ["Japanese", "English"],
+      "expertise": ["Server-Side Programming", "Front-end Programming", "Infrastructure Management", "Team Members Management"]
+    },
+    "occupation": "Software Engineer",
+    "name": "Wade Williams",
+    "age": 35
+  }
+}


### PR DESCRIPTION
## 1. Overview

This PR removes both RuboCop overrides in `ruby/.rubocop.yml` (`Metrics/ClassLength` and `Metrics/MethodLength` excluded for `test/**/*`) and types the reworked test with RBS inline annotations.  
The overrides existed because `test/application_test.rb` inlined three near-identical 56-line Ruby hashes (the unsorted user data plus its ascending- and descending-sorted expectations), pushing the class to 219 lines.  
The hashes are now real JSON fixture files under `test/fixtures/`, loaded through a small `fixture_json` helper. The helper carries `# @rbs` parameter/return annotations, and the `FIXTURES_DIR` constant is typed via `# @rbs skip` + a `# @rbs!` embedded declaration (rbs-inline's `@rbs`-format mechanism for constants; no trailing `#:` comments are used).

## 2. Key Changes & Differences

|File |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`ruby/.rubocop.yml` |`Metrics/ClassLength` + `Metrics/MethodLength` excluded for `test/**/*` |Plugins + `AllCops` only |Both patches deleted. |
|`ruby/test/fixtures/users.json` |Did not exist (data inlined in `user_data`) |Unsorted fixture (user2 → user3 → user1) |`setup` now copies this file into `test/tmp/`. |
|`ruby/test/fixtures/users_sorted_asc.json` / `users_sorted_desc.json` |Did not exist (two 56-line expectation methods) |Sorted expectation fixtures |Loaded via `fixture_json`. |
|`ruby/test/application_test.rb` |219-line class, three 56-line fixture methods |~90-line class; `FIXTURES_DIR` typed as `String` via `# @rbs!`; `fixture_json` annotated `(String) -> Hash[Symbol, untyped]` |All five test cases unchanged in intent; assertions still compare deep-symbolised hashes. |
|`ruby/sig/generated/test/application_test.rbs` |Untyped fixture methods |`FIXTURES_DIR: String`, `def fixture_json: (String basename) -> Hash[Symbol, untyped]` |Regenerated with `rbs-inline --output sig/generated/ .`. |

## 3. Summary

The test class now reads as pure test logic against diff-able JSON fixtures, and the new helper surface is fully typed in the generated signatures.  
Verified with RuboCop 1.88.1 (`6 files inspected, no offenses detected`), rbs-inline 0.14.0 regeneration, and the Minitest suite (`5 runs, 8 assertions, 0 failures, 0 errors, 0 skips`).

Branch commits (newest first):

- `ad6ed61` Use @rbs magic comments instead of trailing #: annotations
- `6716358` Articulate RBS inline types and regenerate signatures
- `2129720` Remove Metrics RuboCop patches
- `d438db9` Extract JSON test fixtures

## 4. References

- [Ruby Style Guide](https://github.com/rubocop/ruby-style-guide)
- [Metrics/ClassLength](https://docs.rubocop.org/rubocop/cops_metrics.html#metricsclasslength)
- [rbs-inline](https://github.com/soutaro/rbs-inline)