### PR TITLE
[python] Optimise Architecture of App

### DIFF
--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import re
-import json
 import os
 import shutil
 import sys
@@ -8,57 +7,7 @@ from collections.abc import Iterator
 
 sys.path.append('./src')
 
-
-_USER_DATA = {
-    'user2': {
-        'name': 'Wade Williams',
-        'age': 45,
-        'gender': 'Male',
-        'occupation': 'Global Trading Marketer',
-        'skills': {
-            'languages': [
-                'Japanese',
-                'English',
-                'Spanish',
-                'German',
-                'French'],
-            'expertise': [
-                'Marketing',
-                'Accounting',
-                'Interpretation',
-                'Translation',
-                'Economics'],
-        },
-    },
-    'user3': {
-        'name': 'Daisy Harris',
-        'age': 30,
-        'gender': 'Female',
-        'occupation': 'High School Teacher',
-        'skills': {
-            'languages': [
-                'English',
-                'Spanish'],
-            'expertise': ['Teaching Foreign Language'],
-        },
-    },
-    'user1': {
-        'name': 'Wade Williams',
-        'age': 35,
-        'occupation': 'Software Engineer',
-        'skills': {
-            'languages': [
-                'Japanese',
-                'English'],
-            'expertise': [
-                'Server-Side Programming',
-                'Front-end Programming',
-                'Infrastructure Management',
-                'Team Members Management',
-            ],
-        },
-    },
-}
+_FIXTURES_DIR = os.path.join('.', 'test', 'fixtures')
 
 
 @pytest.fixture(autouse=True)
@@ -78,8 +27,7 @@ def users_workspace() -> Iterator[tuple[str, str, str]]:
     filename = 'users.json'
     filepath = os.path.join(dirname, filename)
     os.makedirs(dirname, exist_ok=True)
-    with open(filepath, 'w') as f:
-        f.write(json.dumps(_USER_DATA, ensure_ascii=False, indent=2))
+    shutil.copyfile(os.path.join(_FIXTURES_DIR, filename), filepath)
     yield dirname, filename, filepath
     if os.path.exists(dirname):
         shutil.rmtree(dirname)

--- a/python/test/fixtures/users.json
+++ b/python/test/fixtures/users.json
@@ -1,0 +1,31 @@
+{
+  "user2": {
+    "name": "Wade Williams",
+    "age": 45,
+    "gender": "Male",
+    "occupation": "Global Trading Marketer",
+    "skills": {
+      "languages": ["Japanese", "English", "Spanish", "German", "French"],
+      "expertise": ["Marketing", "Accounting", "Interpretation", "Translation", "Economics"]
+    }
+  },
+  "user3": {
+    "name": "Daisy Harris",
+    "age": 30,
+    "gender": "Female",
+    "occupation": "High School Teacher",
+    "skills": {
+      "languages": ["English", "Spanish"],
+      "expertise": ["Teaching Foreign Language"]
+    }
+  },
+  "user1": {
+    "name": "Wade Williams",
+    "age": 35,
+    "occupation": "Software Engineer",
+    "skills": {
+      "languages": ["Japanese", "English"],
+      "expertise": ["Server-Side Programming", "Front-end Programming", "Infrastructure Management", "Team Members Management"]
+    }
+  }
+}

--- a/python/test/fixtures/users_sorted_asc.json
+++ b/python/test/fixtures/users_sorted_asc.json
@@ -1,0 +1,31 @@
+{
+  "user1": {
+    "age": 35,
+    "name": "Wade Williams",
+    "occupation": "Software Engineer",
+    "skills": {
+      "languages": ["Japanese", "English"],
+      "expertise": ["Server-Side Programming", "Front-end Programming", "Infrastructure Management", "Team Members Management"]
+    }
+  },
+  "user2": {
+    "age": 45,
+    "gender": "Male",
+    "name": "Wade Williams",
+    "occupation": "Global Trading Marketer",
+    "skills": {
+      "languages": ["Japanese", "English", "Spanish", "German", "French"],
+      "expertise": ["Marketing", "Accounting", "Interpretation", "Translation", "Economics"]
+    }
+  },
+  "user3": {
+    "age": 30,
+    "gender": "Female",
+    "name": "Daisy Harris",
+    "occupation": "High School Teacher",
+    "skills": {
+      "languages": ["English", "Spanish"],
+      "expertise": ["Teaching Foreign Language"]
+    }
+  }
+}

--- a/python/test/fixtures/users_sorted_desc.json
+++ b/python/test/fixtures/users_sorted_desc.json
@@ -1,0 +1,31 @@
+{
+  "user3": {
+    "skills": {
+      "languages": ["English", "Spanish"],
+      "expertise": ["Teaching Foreign Language"]
+    },
+    "occupation": "High School Teacher",
+    "name": "Daisy Harris",
+    "gender": "Female",
+    "age": 30
+  },
+  "user2": {
+    "skills": {
+      "languages": ["Japanese", "English", "Spanish", "German", "French"],
+      "expertise": ["Marketing", "Accounting", "Interpretation", "Translation", "Economics"]
+    },
+    "occupation": "Global Trading Marketer",
+    "name": "Wade Williams",
+    "gender": "Male",
+    "age": 45
+  },
+  "user1": {
+    "skills": {
+      "languages": ["Japanese", "English"],
+      "expertise": ["Server-Side Programming", "Front-end Programming", "Infrastructure Management", "Team Members Management"]
+    },
+    "occupation": "Software Engineer",
+    "name": "Wade Williams",
+    "age": 35
+  }
+}

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -1,109 +1,37 @@
+"""Tests the JSON data sorter against fixture data under test/fixtures/."""
+
 import json
+import os
 from typing import Any
 
 import pytest
 
 from application import Application
 
+_FIXTURES_DIR = os.path.join('.', 'test', 'fixtures')
+
 
 def _read_json(filepath: str) -> Any:
-    with open(filepath) as f:
+    with open(filepath, encoding='utf-8') as f:
         return json.load(f)
 
 
-_SORTED_BY_ASC = {
-    'user1': {
-        'age': 35,
-        'name': 'Wade Williams',
-        'occupation': 'Software Engineer',
-        'skills': {
-            'languages': ['Japanese', 'English'],
-            'expertise': [
-                'Server-Side Programming',
-                'Front-end Programming',
-                'Infrastructure Management',
-                'Team Members Management',
-            ],
-        },
-    },
-    'user2': {
-        'age': 45,
-        'gender': 'Male',
-        'name': 'Wade Williams',
-        'occupation': 'Global Trading Marketer',
-        'skills': {
-            'languages': [
-                'Japanese', 'English', 'Spanish', 'German', 'French'],
-            'expertise': [
-                'Marketing', 'Accounting', 'Interpretation',
-                'Translation', 'Economics'],
-        },
-    },
-    'user3': {
-        'age': 30,
-        'gender': 'Female',
-        'name': 'Daisy Harris',
-        'occupation': 'High School Teacher',
-        'skills': {
-            'languages': ['English', 'Spanish'],
-            'expertise': ['Teaching Foreign Language'],
-        },
-    },
-}
-
-_SORTED_BY_DESC = {
-    'user3': {
-        'skills': {
-            'languages': ['English', 'Spanish'],
-            'expertise': ['Teaching Foreign Language'],
-        },
-        'occupation': 'High School Teacher',
-        'name': 'Daisy Harris',
-        'gender': 'Female',
-        'age': 30,
-    },
-    'user2': {
-        'skills': {
-            'languages': [
-                'Japanese', 'English', 'Spanish', 'German', 'French'],
-            'expertise': [
-                'Marketing', 'Accounting', 'Interpretation',
-                'Translation', 'Economics'],
-        },
-        'occupation': 'Global Trading Marketer',
-        'name': 'Wade Williams',
-        'gender': 'Male',
-        'age': 45,
-    },
-    'user1': {
-        'skills': {
-            'languages': ['Japanese', 'English'],
-            'expertise': [
-                'Server-Side Programming',
-                'Front-end Programming',
-                'Infrastructure Management',
-                'Team Members Management',
-            ],
-        },
-        'occupation': 'Software Engineer',
-        'name': 'Wade Williams',
-        'age': 35,
-    },
-}
+def _fixture_json(basename: str) -> Any:
+    return _read_json(os.path.join(_FIXTURES_DIR, basename))
 
 
 def test_sort_json_data_by_asc(
         users_workspace: tuple[str, str, str]) -> None:
     dirname, filename, filepath = users_workspace
     Application.run(dirname=dirname, filename=filename, order='asc')
-    assert _read_json(filepath) == _SORTED_BY_ASC
+    assert _read_json(filepath) == _fixture_json('users_sorted_asc.json')
 
 
 def test_sort_json_data_by_desc(
         users_workspace: tuple[str, str, str]) -> None:
     dirname, filename, filepath = users_workspace
     Application.run(dirname=dirname, filename=filename, order='desc')
-    assert _read_json(filepath) == _SORTED_BY_DESC
+    assert _read_json(filepath) == _fixture_json('users_sorted_desc.json')
 
 
 def test_sort_json_data_with_no_filename(


### PR DESCRIPTION
## 1. Overview

This PR mirrors the Ruby-side test cleanup into the `python/` project.  
The input user data and both sorted expectations were inlined as large dict literals (`_USER_DATA` in `conftest.py`; `_SORTED_BY_ASC`/`_SORTED_BY_DESC` in the test module).  
They are now the same three JSON fixture files used by the Ruby suite, copied verbatim into `python/test/fixtures/` and loaded through small helpers; assertions still compare parsed dicts, so behaviour is unchanged.

## 2. Key Changes & Differences

|File |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`python/test/fixtures/users.json` |Did not exist (`_USER_DATA` dict in conftest) |Unsorted input fixture |The `users_workspace` fixture now copies it into `test/tmp/`. |
|`python/test/fixtures/users_sorted_asc.json` / `users_sorted_desc.json` |Did not exist (~40-line expectation dicts) |Sorted expectation fixtures |Loaded via `_fixture_json`. |
|`python/test/conftest.py` |Dumped the inline dict with `json.dumps` |Copies the fixture file; `json` import dropped |Fixture data no longer lives in Python source. |
|`python/test/test_application.py` |~80 lines of expectation dicts |`_fixture_json` helper + module docstring |Test module now contains only test logic. |

## 3. Summary

Ruby and Python suites now share identical fixture content (maintained in each project's `test/fixtures/`), so a data change is a JSON edit in both stacks rather than parallel dict/hash edits.  
Verified in WSL (Python 3.14.6 / pytest 9.0.3): `5 passed`.

Branch commits (newest first):

- `94a6829` Extract JSON test fixtures

## 4. References

- [pytest fixtures](https://docs.pytest.org/en/stable/how-to/fixtures.html)
- https://github.com/hayat01sh1da/json-data-sorters/pull/79