### PR TITLE
[python] Update pip Library Dependencies

### DIFF
--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -15,4 +15,4 @@ pycodestyle==2.14.0
 pyflakes==3.4.0
 Pygments==2.20.0
 pytest==9.0.3
-typing_extensions==4.15.0
+typing_extensions==4.16.0


### PR DESCRIPTION
## 1. Overview

This topic branch carries out routine dependency maintenance for the Python subproject of this
repository. It was cut from `master` and contains a single commit: `e8c9ee1 Update pip library dependencies`.

The update refreshes `typing_extensions` from 4.15.0 to 4.16.0 in `python/requirements.lock`. `typing_extensions`
is not declared in `requirements.txt`; it is resolved transitively by the development toolchain
(`mypy` and friends), so the only file that changes is the lock file.

## 2. Key Changes & Differences

|Libraries |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`typing_extensions`  |`4.15.0` |`4.16.0` |Minor-level update. Backports of the latest `typing` features for older Python runtimes. Not a direct requirement (absent from `requirements.txt`); pulled in by the development toolchain (`mypy` et al.), so the change is lockfile-only. |

## 3. Summary

This is a low-risk, lockfile-only change to a development-toolchain dependency; `requirements.txt`
and all application code are untouched, and the bump is backwards-compatible. Suggested
verification before merge: reinstall from the lock (`pip install -r requirements.lock`) and run
the linters (`flake8`, `mypy`) and `pytest`.

## 4. References

- [typing-extensions on PyPI](https://pypi.org/project/typing-extensions/)
- [typing_extensions CHANGELOG](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md)