### PR TITLE
[github-actions] Setup Daily Library Dependencies Update Cron Job Workflows

### DIFF
--- a/.github/workflows/python--ci.yml
+++ b/.github/workflows/python--ci.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python
+name: Python - CI
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - master
     paths:
       - .github/actions/setup-python/action.yml
-      - .github/workflows/python.yml
+      - .github/workflows/python--ci.yml
       - .python-version
       - requirements.txt
       - requirements.lock
@@ -18,7 +18,7 @@ on:
   pull_request:
     paths:
       - .github/actions/setup-python/action.yml
-      - .github/workflows/python.yml
+      - .github/workflows/python--ci.yml
       - .python-version
       - requirements.txt
       - requirements.lock
@@ -43,7 +43,7 @@ jobs:
           filters: |
             python:
             - .github/actions/setup-python/action.yml
-            - .github/workflows/python.yml
+            - .github/workflows/python--ci.yml
             - .python-version
             - requirements.txt
             - requirements.lock

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -1,0 +1,88 @@
+# This workflow updates pip library dependencies every day and opens a pull
+# request when any dependency changes are detected.
+
+name: Python - Daily Dependencies Update
+
+on:
+  schedule:
+    # 0:00 JST every day
+    - cron: "0 15 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: .python-version
+      - name: Update pip Library Dependencies
+        working-directory: ./python
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt --upgrade
+          pip freeze > requirements.lock
+      - name: Generate Pull Request Description
+        env:
+          BODY_PATH: ${{ runner.temp }}/pr_body.md
+        run: |
+          ROWS=$(git diff --unified=0 -- python/requirements.lock \
+            | grep -E '^[+-][A-Za-z0-9]' \
+            | sed -E 's/^(.)/\1 /; s/==/ /' \
+            | awk '{ if ($1 == "-") before[$2] = $3; else after[$2] = $3 }
+              END {
+                for (name in after) {
+                  if (name in before) {
+                    if (before[name] != after[name]) print "|" name " |" before[name] " |" after[name] " |Updated |"
+                    delete before[name]
+                  } else {
+                    print "|" name " |- |" after[name] " |Added |"
+                  }
+                }
+                for (name in before) print "|" name " |" before[name] " |- |Removed |"
+              }' \
+            | sort)
+          if [ -z "$ROWS" ]; then ROWS='| | | |No dependency changes detected |'; fi
+          cat > "$BODY_PATH" <<EOF
+          ## 1. Overview
+
+          This pull request was created automatically by the Python - Daily Dependencies Update workflow.
+          It upgrades pip itself, upgrades every library listed in requirements.txt to the latest available versions, and regenerates requirements.lock:
+
+          ~~~console
+          pip install --upgrade pip
+          pip install -r requirements.txt --upgrade
+          pip freeze > requirements.lock
+          ~~~
+
+          ## 2. Key Changes & Differences
+
+          |Libraries |Before |After |Changes & Differences |
+          |:-|:-|:-|:-|
+          $ROWS
+
+          ## 3. Summary
+
+          All pip library dependencies in python/requirements.lock are now up to date.
+          Please make sure that all CI workflows pass before merging this pull request.
+
+          ## 4. References
+
+          - [Python - Daily Dependencies Update workflow run](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)
+          - [pip install documentation](https://pip.pypa.io/en/stable/cli/pip_install/)
+          EOF
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: daily/python-dependency-updates
+          delete-branch: true
+          commit-message: "[Daily][Python] Update pip Library Dependencies"
+          title: "[Daily][Python] Update pip Library Dependencies"
+          body-path: ${{ runner.temp }}/pr_body.md

--- a/.github/workflows/ruby--ci.yml
+++ b/.github/workflows/ruby--ci.yml
@@ -5,7 +5,7 @@
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
-name: Ruby
+name: Ruby - CI
 
 on:
   push:
@@ -13,7 +13,7 @@ on:
       - master
     paths:
       - .github/actions/setup-ruby/action.yml
-      - .github/workflows/ruby.yml
+      - .github/workflows/ruby--ci.yml
       - .ruby-version
       - ruby/**/*.rb
       - ruby/**/*.rbs
@@ -25,7 +25,7 @@ on:
   pull_request:
     paths:
       - .github/actions/setup-ruby/action.yml
-      - .github/workflows/ruby.yml
+      - .github/workflows/ruby--ci.yml
       - .ruby-version
       - ruby/**/*.rb
       - ruby/**/*.rbs
@@ -55,14 +55,14 @@ jobs:
           filters: |
             ruby:
               - .github/actions/setup-ruby/action.yml
-              - .github/workflows/ruby.yml
+              - .github/workflows/ruby--ci.yml
               - .ruby-version
               - ruby/**/*.rb
               - ruby/Gemfile
               - ruby/Gemfile.lock
             rubocop:
               - .github/actions/setup-ruby/action.yml
-              - .github/workflows/ruby.yml
+              - .github/workflows/ruby--ci.yml
               - .ruby-version
               - ruby/**/*.rb
               - ruby/Gemfile
@@ -71,7 +71,7 @@ jobs:
               - ruby/.rubocop_todo.yml
             steep:
               - .github/actions/setup-ruby/action.yml
-              - .github/workflows/ruby.yml
+              - .github/workflows/ruby--ci.yml
               - .ruby-version
               - ruby/**/*.rb
               - ruby/**/*.rbs

--- a/.github/workflows/ruby--daily-dependencies-update.yml
+++ b/.github/workflows/ruby--daily-dependencies-update.yml
@@ -1,0 +1,88 @@
+# This workflow updates gem dependencies every day and opens a pull request
+# when any dependency changes are detected.
+
+name: Ruby - Daily Dependencies Update
+
+on:
+  schedule:
+    # 0:00 JST every day
+    - cron: "0 15 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+      - name: Update Gem Dependencies
+        working-directory: ./ruby
+        env:
+          BUNDLE_FROZEN: "false"
+        run: |
+          gem update --system
+          gem install bundler
+          bundle update --all
+      - name: Generate Pull Request Description
+        env:
+          BODY_PATH: ${{ runner.temp }}/pr_body.md
+        run: |
+          ROWS=$(git diff --unified=0 -- ruby/Gemfile.lock \
+            | grep -E '^[+-] {4}[^ ]+ \([0-9]' \
+            | sed -E 's/^(.) +/\1 /; s/[()]//g' \
+            | awk '{ if ($1 == "-") before[$2] = $3; else after[$2] = $3 }
+              END {
+                for (name in after) {
+                  if (name in before) {
+                    if (before[name] != after[name]) print "|" name " |" before[name] " |" after[name] " |Updated |"
+                    delete before[name]
+                  } else {
+                    print "|" name " |- |" after[name] " |Added |"
+                  }
+                }
+                for (name in before) print "|" name " |" before[name] " |- |Removed |"
+              }' \
+            | sort)
+          if [ -z "$ROWS" ]; then ROWS='| | | |No dependency changes detected |'; fi
+          cat > "$BODY_PATH" <<EOF
+          ## 1. Overview
+
+          This pull request was created automatically by the Ruby - Daily Dependencies Update workflow.
+          It upgrades RubyGems and Bundler, and updates every gem to the latest version allowed by the Gemfile:
+
+          ~~~console
+          gem update --system
+          gem install bundler
+          bundle update --all
+          ~~~
+
+          ## 2. Key Changes & Differences
+
+          |Gems |Before |After |Changes & Differences |
+          |:-|:-|:-|:-|
+          $ROWS
+
+          ## 3. Summary
+
+          All gem dependencies in ruby/Gemfile.lock are now up to date.
+          Please make sure that all CI workflows pass before merging this pull request.
+
+          ## 4. References
+
+          - [Ruby - Daily Dependencies Update workflow run](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)
+          - [bundle update documentation](https://bundler.io/man/bundle-update.1.html)
+          EOF
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: daily/ruby-dependency-updates
+          delete-branch: true
+          commit-message: "[Daily][Ruby] Update Gem dependencies"
+          title: "[Daily][Ruby] Update Gem dependencies"
+          body-path: ${{ runner.temp }}/pr_body.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-[![Actions Status: Python](https://github.com/hayat01sh1da/json-data-sorters/workflows/Python/badge.svg)](https://github.com/hayat01sh1da/json-data-sorters/actions?query=workflow%3A%22Python%22)
-[![Actions Status: Ruby](https://github.com/hayat01sh1da/json-data-sorters/workflows/Ruby/badge.svg)](https://github.com/hayat01sh1da/json-data-sorters/actions?query=workflow%3A%22Ruby%22)
+[![Actions Status: Python - CI](https://github.com/hayat01sh1da/json-data-sorters/workflows/Python%20-%20CI/badge.svg)](https://github.com/hayat01sh1da/json-data-sorters/actions?query=workflow%3A%22Python%20-%20CI%22)
+[![Actions Status: Python - Daily Dependencies Update](https://github.com/hayat01sh1da/json-data-sorters/workflows/Python%20-%20Daily%20Dependencies%20Update/badge.svg)](https://github.com/hayat01sh1da/json-data-sorters/actions?query=workflow%3A%22Python%20-%20Daily%20Dependencies%20Update%22)
+[![Actions Status: Ruby - CI](https://github.com/hayat01sh1da/json-data-sorters/workflows/Ruby%20-%20CI/badge.svg)](https://github.com/hayat01sh1da/json-data-sorters/actions?query=workflow%3A%22Ruby%20-%20CI%22)
+[![Actions Status: Ruby - Daily Dependencies Update](https://github.com/hayat01sh1da/json-data-sorters/workflows/Ruby%20-%20Daily%20Dependencies%20Update/badge.svg)](https://github.com/hayat01sh1da/json-data-sorters/actions?query=workflow%3A%22Ruby%20-%20Daily%20Dependencies%20Update%22)
 [![Actions Status: CodeQL](https://github.com/hayat01sh1da/json-data-sorters/workflows/CodeQL/badge.svg)](https://github.com/hayat01sh1da/json-data-sorters/actions?query=workflow%3A%22CodeQL%22)
 
 ## 1. Common Environment


### PR DESCRIPTION
## 1. Overview

This branch sets up daily dependencies-update cron jobs powered by GitHub Actions.  
Each new workflow runs at 0:00 JST every day (`cron: "0 15 * * *"` in UTC), updates the language-specific dependencies, and opens a pull request whose description follows PULL_REQUEST_TEMPLATE.md — including a dynamically generated Key Changes & Differences table built from the lockfile diff — whenever any dependency changes are detected.  
It also renames the existing CI workflows to the `{language/framework}--ci.yml` naming convention and suffixes their workflow names with " - CI", so that CI and cron workflows are consistently distinguishable.  
Self-referencing filenames inside the renamed workflows' paths filters have been updated accordingly.

## 2. Key Changes & Differences

|Workflows |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|Python - Daily Dependencies Update |- |.github/workflows/python--daily-dependencies-update.yml |Added a daily dependencies-update cron workflow (0:00 JST) that opens a pull request when dependency changes are detected |
|Python - CI |.github/workflows/python.yml |.github/workflows/python--ci.yml |Renamed with a `--ci` suffix; workflow name suffixed with " - CI"; self-referencing paths filters updated to the new filename |
|Ruby - Daily Dependencies Update |- |.github/workflows/ruby--daily-dependencies-update.yml |Added a daily dependencies-update cron workflow (0:00 JST) that opens a pull request when dependency changes are detected |
|Ruby - CI |.github/workflows/ruby.yml |.github/workflows/ruby--ci.yml |Renamed with a `--ci` suffix; workflow name suffixed with " - CI"; self-referencing paths filters updated to the new filename |

## 3. Summary

2 CI workflow(s) renamed and 2 daily cron workflow(s) added.
The cron workflows will open pull requests with the following titles when dependency updates are available:

- `[Daily][Python] Update pip Library Dependencies`
- `[Daily][Ruby] Update Gem dependencies`

Merging this pull request requires no further action, but note that pull requests created with the default GITHUB_TOKEN do not trigger the CI workflows; use a personal access token or GitHub App token in peter-evans/create-pull-request if CI should run on them, and make sure "Allow GitHub Actions to create and approve pull requests" is enabled in the repository settings.

## 4. References

- [Python - Daily Dependencies Update](https://github.com/hayat01sh1da/json-data-sorters/blob/hayat01sh1da/github-actions/setup-daily-library-dependencies-update-cron-job-workflows/.github/workflows/python--daily-dependencies-update.yml)
- [Python - CI](https://github.com/hayat01sh1da/json-data-sorters/blob/hayat01sh1da/github-actions/setup-daily-library-dependencies-update-cron-job-workflows/.github/workflows/python--ci.yml)
- [Ruby - Daily Dependencies Update](https://github.com/hayat01sh1da/json-data-sorters/blob/hayat01sh1da/github-actions/setup-daily-library-dependencies-update-cron-job-workflows/.github/workflows/ruby--daily-dependencies-update.yml)
- [Ruby - CI](https://github.com/hayat01sh1da/json-data-sorters/blob/hayat01sh1da/github-actions/setup-daily-library-dependencies-update-cron-job-workflows/.github/workflows/ruby--ci.yml)
- [Events that trigger workflows: schedule](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)
- [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)