### PR TITLE
[GitHub Actions] Modify Scripts to Detect Update More Accurately

### DIFF
--- a/.github/scripts/dependency_report.sh
+++ b/.github/scripts/dependency_report.sh
@@ -18,6 +18,10 @@
 # Package-manager updates are reported too: pip as a regular requirements.lock
 # entry, bundler from the lockfile's BUNDLED WITH section, and pnpm from the
 # manifest's packageManager field.
+# For gems, changes to the version requirements in the lockfile's DEPENDENCIES
+# section are also reported, so a diff that only tightens requirements (e.g.
+# `minitest (~> 5.25)` -> `minitest (~> 5.27.0)`) is never summarised as
+# "No dependency changes detected".
 set -euo pipefail
 
 ecosystem=$1
@@ -73,22 +77,37 @@ level() {
   printf 'Patch-level update'
 }
 
-declare -A before after direct
+declare -A before after req_before req_after direct
 
 while IFS= read -r line; do
+  requirement=''
   case $ecosystem in
     pip)
       [[ $line =~ ^([+-])([A-Za-z0-9][A-Za-z0-9._-]*)==([^[:space:]]+)$ ]] || continue
       ;;
     gem)
-      [[ $line =~ ^([+-])\ {4}([^\ ]+)\ \(([0-9][^\)]*)\)$ ]] || continue
+      # 4-space indent: resolved versions in the specs section. 2-space indent:
+      # version requirements in the DEPENDENCIES section (mirrors the Gemfile).
+      if [[ $line =~ ^([+-])\ {4}([^\ ]+)\ \(([0-9][^\)]*)\)$ ]]; then
+        :
+      elif [[ $line =~ ^([+-])\ \ ([^\ ]+)\ \(([^\)]+)\)$ ]]; then
+        requirement=1
+      else
+        continue
+      fi
       ;;
     *)
       [[ $line == *'('* ]] && continue
       [[ $line =~ ^([+-])\ \ \'?(.+)@([0-9][^\':]*)\'?:?$ ]] || continue
       ;;
   esac
-  if [ "${BASH_REMATCH[1]}" = '-' ]; then
+  if [ -n "$requirement" ]; then
+    if [ "${BASH_REMATCH[1]}" = '-' ]; then
+      req_before[${BASH_REMATCH[2]}]=${BASH_REMATCH[3]}
+    else
+      req_after[${BASH_REMATCH[2]}]=${BASH_REMATCH[3]}
+    fi
+  elif [ "${BASH_REMATCH[1]}" = '-' ]; then
     before[${BASH_REMATCH[2]}]=${BASH_REMATCH[3]}
   else
     after[${BASH_REMATCH[2]}]=${BASH_REMATCH[3]}
@@ -158,13 +177,21 @@ while IFS= read -r name; do
   [ -n "$name" ] || continue
   old=${before[$name]:-}
   new=${after[$name]:-}
-  [ "$old" = "$new" ] && continue
-  if [ -n "$old" ] && [ -n "$new" ]; then
-    what=$(level "$old" "$new")
-  elif [ -n "$new" ]; then
-    what='Newly added'
+  if [ "$old" != "$new" ]; then
+    if [ -n "$old" ] && [ -n "$new" ]; then
+      what=$(level "$old" "$new")
+    elif [ -n "$new" ]; then
+      what='Newly added'
+    else
+      what='Removed'
+    fi
   else
-    what='Removed'
+    # No resolved-version change: report a requirement-only change (gem), e.g.
+    # the lockfile's DEPENDENCIES section catching up with the Gemfile.
+    old=${req_before[$name]:-}
+    new=${req_after[$name]:-}
+    [ "$old" = "$new" ] && continue
+    what='Version requirement update'
   fi
   description=$(clean "$(describe "$name")")
   normalised=$name
@@ -187,7 +214,7 @@ while IFS= read -r name; do
   old_cell=${old:+\`$old\`}
   new_cell=${new:+\`$new\`}
   rows+="|[\`${name}\`](${registry_url}) |${old_cell:--} |${new_cell:--} |${notes} |"$'\n'
-done < <(printf '%s\n' "${!before[@]}" "${!after[@]}" | sort -fu)
+done < <(printf '%s\n' "${!before[@]}" "${!after[@]}" "${!req_before[@]}" "${!req_after[@]}" | sort -fu)
 
 echo "|${label} |Before |After |Changes & Differences |"
 echo '|:-|:-|:-|:-|'

--- a/.github/workflows/ruby--daily-dependencies-update.yml
+++ b/.github/workflows/ruby--daily-dependencies-update.yml
@@ -33,6 +33,8 @@ jobs:
           bundle update --all
       - name: Mirror Updated Versions to Gemfile
         working-directory: ./ruby
+        env:
+          BUNDLE_FROZEN: "false"
         run: |
           ruby <<'RUBY'
           versions = File.read('Gemfile.lock').scan(/^    (\S+) \((\d+(?:\.\d+)*)\)$/).to_h
@@ -41,6 +43,7 @@ jobs:
           end
           File.write('Gemfile', gemfile)
           RUBY
+          bundle lock --add-checksums
       - name: Generate Pull Request Description
         env:
           BODY_PATH: ${{ runner.temp }}/pr_body.md
@@ -50,7 +53,7 @@ jobs:
           ## 1. Overview
 
           This pull request was created automatically by the Ruby - Daily Dependencies Update workflow.
-          It upgrades RubyGems and Bundler, updates every gem to the latest version allowed by the Gemfile, and mirrors the updated versions to the Gemfile:
+          It upgrades RubyGems and Bundler, updates every gem to the latest version allowed by the Gemfile, mirrors the updated versions to the Gemfile, and re-locks Gemfile.lock so its DEPENDENCIES section stays in sync with the Gemfile:
 
           ~~~console
           gem update --system


### PR DESCRIPTION
## 1. Overview

This pull request makes the daily dependencies update automation detect and describe dependency updates more accurately.  
The `Mirror Updated Versions to Gemfile` step used to rewrite the Gemfile after `bundle update --all` without re-locking, which left the `DEPENDENCIES` section of `Gemfile.lock` out of sync with the Gemfile and produced a follow-up pull request on the next day.  
In addition, `dependency_report.sh` only parsed resolved-version lines in the lockfile diff, so such a requirement-only diff was summarised as "No dependency changes detected", as seen on hayat01sh1da/spreen-wiki#120.  
This pull request fixes both: the workflow now re-locks `Gemfile.lock` right after mirroring, and the report script also parses version requirement changes in the `DEPENDENCIES` section.  

## 2. Key Changes & Differences

|Files |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`.github/scripts/dependency_report.sh` |Parsed only resolved-version lines (4-space-indented `specs` entries) in the `Gemfile.lock` diff, so a diff that only changed version requirements was reported as "No dependency changes detected" |Also parses version requirement changes in the `DEPENDENCIES` section (2-space-indented entries) and reports them as "Version requirement update" rows |Requirement-only lockfile diffs now appear in the `2. Key Changes & Differences` table of daily pull requests; the pip and pnpm report paths are unchanged |
|`.github/workflows/ruby--daily-dependencies-update.yml` |The `Mirror Updated Versions to Gemfile` step rewrote the Gemfile after `bundle update --all` without re-locking, leaving the `DEPENDENCIES` section of `Gemfile.lock` stale |The step runs `bundle lock --add-checksums` (with `BUNDLE_FROZEN: "false"`) right after mirroring, and the generated pull request body mentions the re-lock |`Gemfile` and `Gemfile.lock` are committed in sync within a single daily pull request, preventing a follow-up requirement-only pull request on the next day |

## 3. Summary

- `dependency_report.sh` now reports version requirement changes in the `DEPENDENCIES` section of `Gemfile.lock` instead of "No dependency changes detected".
- The daily dependencies update workflow(s) re-lock `Gemfile.lock` with `bundle lock --add-checksums` right after mirroring the updated versions to the Gemfile, so both files are committed in sync within a single pull request.
- These are the same fixes as applied to the spreen-wiki repository, where the issue was found on its daily pull request.

## 4. References

- [.github/scripts/dependency_report.sh](https://github.com/hayat01sh1da/json-data-sorters/blob/hayat01sh1da/github-actions/modify-scripts-to-detect-updates-more-accurately/.github/scripts/dependency_report.sh)
- [.github/workflows/ruby--daily-dependencies-update.yml](https://github.com/hayat01sh1da/json-data-sorters/blob/hayat01sh1da/github-actions/modify-scripts-to-detect-updates-more-accurately/.github/workflows/ruby--daily-dependencies-update.yml)
- [spreen-wiki PR #120, whose description missed the requirement updates](https://github.com/hayat01sh1da/spreen-wiki/pull/120)
- [bundle lock documentation](https://bundler.io/man/bundle-lock.1.html)
